### PR TITLE
LRU caching for model and POS tagging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 filelock
 language_check
+lru-dict
 nltk
 numpy<1.17
 pandas


### PR DESCRIPTION
clocked a 6% speed increase for greedy word swap (honestly, I thought it would be way bigger)

probably makes a bigger difference for methods which utilize call_model more frequently, like the genetic algorithm