### PR TITLE
rewrite logger to prevent additional storage, fix caching bug

### DIFF
--- a/textattack/attack_methods/attack.py
+++ b/textattack/attack_methods/attack.py
@@ -89,19 +89,11 @@ class Attack:
         raise NotImplementedError()
         
     def _call_model_uncached(self, tokenized_text_list, batch_size=8):
-        """
-        Returns model predictions for a list of TokenizedText objects. 
-        
+        """ Queries model and returns predictions for a list of TokenizedText 
+            objects. 
         """
         if not len(tokenized_text_list):
             return torch.tensor([])
-        try:
-            self.num_queries += len(tokenized_text_list)
-        except AttributeError:
-            # If some outside class is just using the attack for its `call_model`
-            # function, then `self.num_queries` will not have been initialized.
-            # In this case, just continue.
-            pass
         ids = [t.ids for t in tokenized_text_list]
         ids = torch.tensor(ids).to(utils.get_device()) 
         #
@@ -146,6 +138,18 @@ class Attack:
         return scores
     
     def _call_model(self, tokenized_text_list):
+        """ Gets predictions for a list of `TokenizedText` objects.
+        
+            Gets prediction from cache if possible. If prediction is not in the 
+            cache, queries model and stores prediction in cache.
+        """
+        try:
+            self.num_queries += len(tokenized_text_list)
+        except AttributeError:
+            # If some outside class is just using the attack for its `call_model`
+            # function, then `self.num_queries` will not have been initialized.
+            # In this case, just continue.
+            pass
         uncached_list = [text for text in tokenized_text_list if text not in self._call_model_cache]
         scores = self._call_model_uncached(uncached_list)
         for text, score in zip(uncached_list, scores):

--- a/textattack/loggers/attack_logger.py
+++ b/textattack/loggers/attack_logger.py
@@ -1,10 +1,5 @@
-import difflib
 import numpy as np
-import os
 import torch
-import random
-import statistics
-import time
 
 from textattack.attack_results import AttackResult, FailedAttackResult, SkippedAttackResult
 
@@ -17,13 +12,7 @@ class AttackLogger:
         self.loggers = []
         self.results = []
         self.max_words_changed = 0
-        self.examples_completed = 0
-        self.max_seq_length = 10000
-        self.perturbed_word_percentages = []
-        self.num_words_changed_until_success = [0] * self.max_seq_length
-        self.successful_attacks = 0
-        self.failed_attacks = 0
-        self.skipped_attacks = 0
+        self.max_seq_len = 512
 
     def enable_stdout(self):
         self.loggers.append(FileLogger(stdout=True))
@@ -39,24 +28,8 @@ class AttackLogger:
 
     def log_result(self, result):
         self.results.append(result)
-        self.examples_completed += 1
         for logger in self.loggers:
-            logger.log_attack_result(result, self.examples_completed)
-        if isinstance(result, FailedAttackResult):
-            self.failed_attacks += 1
-            return
-        if isinstance(result, SkippedAttackResult):
-            self.skipped_attacks += 1
-            return
-        self.successful_attacks += 1
-        num_words_changed =  len(result.original_text.all_words_diff(result.perturbed_text))
-        self.num_words_changed_until_success[num_words_changed-1] += 1
-        self.max_words_changed = max(self.max_words_changed,num_words_changed)
-        if num_words_changed > 0:
-            perturbed_word_percentage = num_words_changed * 100.0 / len(result.original_text.words)
-        else:
-            perturbed_word_percentage = 0
-        self.perturbed_word_percentages.append(perturbed_word_percentage)
+            logger.log_attack_result(result)
     
     def log_results(self, results):
         for result in results:
@@ -81,44 +54,61 @@ class AttackLogger:
             ['Model:', model_name],
         ]
         self._log_rows(attack_detail_rows, 'Attack Details', 'attack_details')
-
-    def _log_num_words_changed(self):
-        numbins = max(self.max_words_changed, 10)
-        for logger in self.loggers:
-            logger.log_hist(self.num_words_changed_until_success[:numbins],
-                numbins=numbins, title='Num Words Perturbed', window_id='num_words_perturbed')
     
     def log_summary(self):
         total_attacks = len(self.results)
         if total_attacks == 0:
             return
+        # Count things about attacks.
+        all_num_words = np.zeros(len(self.results))
+        perturbed_word_percentages = np.zeros(len(self.results))
+        num_words_changed_until_success =  np.zeros(self.max_seq_len)
+        failed_attacks = 0
+        skipped_attacks = 0
+        successful_attacks = 0
+        max_words_changed = None
+        for i, result in enumerate(self.results):
+            if isinstance(result, FailedAttackResult):
+                failed_attacks += 1
+            elif isinstance(result, SkippedAttackResult):
+                skipped_attacks += 1
+            else: 
+                successful_attacks += 1
+            num_words_changed =  len(result.original_text.all_words_diff(result.perturbed_text))
+            num_words_changed_until_success[num_words_changed-1] += 1
+            max_words_changed = max(max_words_changed or num_words_changed, num_words_changed)
+            if num_words_changed > 0:
+                perturbed_word_percentage = num_words_changed * 100.0 / len(result.original_text.words)
+            else:
+                perturbed_word_percentage = 0
+            perturbed_word_percentages[i] = perturbed_word_percentage
+            num_words_changed_until_success[i] = len(result.original_text.words)
+        
         # Original classifier success rate on these samples.
-        original_accuracy = total_attacks * 100.0 / (total_attacks + self.skipped_attacks) 
+        original_accuracy = (total_attacks - skipped_attacks)  * 100.0 / (total_attacks) 
         original_accuracy = str(round(original_accuracy, 2)) + '%'
+        
         # New classifier success rate on these samples.
-        accuracy_under_attack = (total_attacks - self.successful_attacks) * 100.0 / (total_attacks + self.skipped_attacks)
+        accuracy_under_attack = (total_attacks - skipped_attacks - successful_attacks) * 100.0 / (total_attacks - skipped_attacks)
         accuracy_under_attack = str(round(accuracy_under_attack, 2)) + '%'
-        # Attack success rate
-        if self.successful_attacks + self.failed_attacks == 0:
+        
+        # Attack success rate.
+        if successful_attacks + failed_attacks == 0:
             attack_success_rate = 0
         else:
-            attack_success_rate = self.successful_attacks * 100.0 / (self.successful_attacks + self.failed_attacks) 
-        if not len(self.perturbed_word_percentages):
-            average_perc_words_perturbed = 0
-        else:
-            average_perc_words_perturbed = statistics.mean(self.perturbed_word_percentages)
-            
+            attack_success_rate = successful_attacks * 100.0 / (successful_attacks + failed_attacks) 
         attack_success_rate = str(round(attack_success_rate, 2)) + '%'
+        
+        average_perc_words_perturbed = perturbed_word_percentages.mean()
         average_perc_words_perturbed = str(round(average_perc_words_perturbed, 2)) + '%'
         
-        all_num_words = np.array([len(result.original_text.words) for result in self.results])
         average_num_words = all_num_words.mean()
         average_num_words = str(round(average_num_words, 2))
         
         summary_table_rows = [
-            ['Number of successful attacks:', str(self.successful_attacks)],
-            ['Number of failed attacks:', str(self.failed_attacks)],
-            ['Number of skipped attacks:', str(self.skipped_attacks)],
+            ['Number of successful attacks:', str(successful_attacks)],
+            ['Number of failed attacks:', str(failed_attacks)],
+            ['Number of skipped attacks:', str(skipped_attacks)],
             ['Original accuracy:', original_accuracy],
             ['Accuracy under attack:', accuracy_under_attack],
             ['Attack success rate:', attack_success_rate],
@@ -126,9 +116,13 @@ class AttackLogger:
             ['Average num. words per input:', average_num_words],
         ]
         
-        num_queries = [r.num_queries for r in self.results]
-        avg_num_queries = statistics.mean(num_queries) if len(num_queries) else 0
+        num_queries = np.array([r.num_queries for r in self.results])
+        avg_num_queries = num_queries.mean()
         avg_num_queries = str(round(avg_num_queries, 2))
         summary_table_rows.append(['Avg num queries:', avg_num_queries])
         self._log_rows(summary_table_rows, 'Attack Results', 'attack_results_summary')
-        self._log_num_words_changed()
+        # Show histogram of words changed.
+        numbins = max(self.max_words_changed, 10)
+        for logger in self.loggers:
+            logger.log_hist(num_words_changed_until_success[:numbins],
+                numbins=numbins, title='Num Words Perturbed', window_id='num_words_perturbed')

--- a/textattack/loggers/csv_logger.py
+++ b/textattack/loggers/csv_logger.py
@@ -14,7 +14,7 @@ class CSVLogger(Logger):
         self.df = pd.DataFrame()
         self._flushed = True
 
-    def log_attack_result(self, result, examples_completed):
+    def log_attack_result(self, result):
         if isinstance(result, FailedAttackResult):
             return
         color_method = None if self.plain else 'file'

--- a/textattack/loggers/file_logger.py
+++ b/textattack/loggers/file_logger.py
@@ -16,10 +16,12 @@ class FileLogger(Logger):
             self.fout = open(filename, 'w')
         else:
             self.fout = filename
+        self.num_results = 0
 
-    def log_attack_result(self, result, examples_completed):
+    def log_attack_result(self, result):
+        self.num_results += 1
         color_method = 'stdout' if self.stdout else 'file'
-        self.fout.write('-'*45 + ' Result ' + str(examples_completed) + ' ' + '-'*45 + '\n')
+        self.fout.write('-'*45 + ' Result ' + str(self.num_results) + ' ' + '-'*45 + '\n')
         self.fout.write(result.__str__(color_method=color_method))
         self.fout.write('\n')
 

--- a/textattack/loggers/visdom_logger.py
+++ b/textattack/loggers/visdom_logger.py
@@ -29,7 +29,7 @@ class VisdomLogger(Logger):
         self.windows = {}
         self.sample_rows = []
 
-    def log_attack_result(self, result, examples_completed):
+    def log_attack_result(self, result):
         text_a, text_b = result.diff_color(color_method='html')
         result_str = result.result_str(color_method='html')
         self.sample_rows.append([result_str,text_a,text_b])


### PR DESCRIPTION
now call_model should be counted even when examples are in the cache