### PR TITLE
fix masking bug

### DIFF
--- a/textattack/constraints/semantics/sentence_encoders/sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/sentence_encoder.py
@@ -133,7 +133,7 @@ class SentenceEncoder(Constraint):
                 scores[i] = 1
             x_adv.attack_attrs['similarity_score'] = scores[i].item()
         mask = (scores >= self.threshold)
-        return np.array(x_adv_list)[mask.cpu().numpy()]
+        return np.array(x_adv_list)[mask.cpu().numpy().nonzero()]
     
     def __call__(self, x, x_adv):
         return self.sim_score(x.text, x_adv.text) >= self.threshold 


### PR DESCRIPTION
Incorrect use of boolean mask. We want to select items corresponding to nonzero indices of the boolean array, but what happens is something else.
For example, 
```
>>> import numpy as np
>>> a = np.array([1,2,3,4,5])
>>> b = np.array([0,1,0,1,0])
>>> a[b]
array([1, 2, 1, 2, 1])
```

We want `array([2,4])`, but instead we get `array([1,2,1,21])`