### PR TITLE
Wordnet transformation

### DIFF
--- a/scripts/run_attack_args_helper.py
+++ b/scripts/run_attack_args_helper.py
@@ -74,6 +74,7 @@ DATASET_BY_MODEL = {
 }
 
 TRANSFORMATION_CLASS_NAMES = {
+    'word-swap-wordnet':               'textattack.transformations.WordSwapWordNet',
     'word-swap-embedding':             'textattack.transformations.WordSwapEmbedding',
     'word-swap-homoglyph':             'textattack.transformations.WordSwapHomoglyph',
     'word-swap-neighboring-char-swap': 'textattack.transformations.WordSwapNeighboringCharacterSwap',
@@ -278,10 +279,11 @@ def parse_logger_from_args(args):# Create logger
     # CSV
     if args.enable_csv:
         outfile_name = 'attack-{}.csv'.format(out_time)
-        plain = args.enable_csv == 'plain'
+        color_method = None if args.enable_csv == 'plain' else 'file'
         csv_path = os.path.join(args.out_dir, outfile_name)
-        attack_logger.add_output_csv(csv_path, plain)
+        attack_logger.add_output_csv(csv_path, color_method)
         print('Logging to CSV at path {}.'.format(csv_path))
+
 
     # Visdom
     if args.enable_visdom:

--- a/textattack/transformations/__init__.py
+++ b/textattack/transformations/__init__.py
@@ -6,3 +6,4 @@ from .word_swap_neighboring_character_swap import WordSwapNeighboringCharacterSw
 from .word_swap_random_character_deletion import WordSwapRandomCharacterDeletion
 from .word_swap_random_character_insertion import WordSwapRandomCharacterInsertion
 from .word_swap_random_character_substitution import WordSwapRandomCharacterSubstitution
+from .word_swap_wordnet import WordSwapWordNet

--- a/textattack/transformations/word_swap.py
+++ b/textattack/transformations/word_swap.py
@@ -50,11 +50,15 @@ class WordSwap(Transformation):
         word_swaps = []
         for i in indices_to_replace:
             word_to_replace = words[i]
+            # Don't replace stopwords.
             if not self.replace_stopwords and word_to_replace.lower() in self.stopwords:
                 continue
             replacement_words = self._get_replacement_words(word_to_replace)
             new_tokenized_texts = []
             for r in replacement_words:
+                # Don't replace with numbers, punctuation, or other non-letter characters.
+                if not is_word(r):
+                    continue
                 new_tokenized_texts.append(tokenized_text.replace_word_at_index(i, r))
             transformations.extend(new_tokenized_texts)
         
@@ -63,3 +67,9 @@ class WordSwap(Transformation):
     
     def extra_repr_keys(self): 
         return ['replace_stopwords']
+
+def is_word(s):
+    """ String `s` counts as a word if it has at least one letter. """
+    for c in s:
+        if c.isalpha(): return True
+    return False 

--- a/textattack/transformations/word_swap_homoglyph.py
+++ b/textattack/transformations/word_swap_homoglyph.py
@@ -1,11 +1,10 @@
 import numpy as np
-import os
 
 from textattack.shared import utils
 from textattack.transformations.word_swap import WordSwap
 
 class WordSwapHomoglyph(WordSwap):
-    """ Transforms an input by replacing its words with visually-similar words using homoglyph swaps.
+    """ Transforms an input by replacing its words with visually similar words using homoglyph swaps.
     """
 
     def __init__(self, replace_stopwords=False):

--- a/textattack/transformations/word_swap_neighboring_character_swap.py
+++ b/textattack/transformations/word_swap_neighboring_character_swap.py
@@ -1,5 +1,4 @@
 import numpy as np
-import os
 
 from textattack.shared import utils
 from textattack.transformations.word_swap import WordSwap

--- a/textattack/transformations/word_swap_random_character_deletion.py
+++ b/textattack/transformations/word_swap_random_character_deletion.py
@@ -1,5 +1,4 @@
 import numpy as np
-import os
 
 from textattack.shared import utils
 from textattack.transformations.word_swap import WordSwap

--- a/textattack/transformations/word_swap_random_character_insertion.py
+++ b/textattack/transformations/word_swap_random_character_insertion.py
@@ -1,5 +1,4 @@
 import numpy as np
-import os
 
 from textattack.shared import utils
 from textattack.transformations.word_swap import WordSwap

--- a/textattack/transformations/word_swap_random_character_substitution.py
+++ b/textattack/transformations/word_swap_random_character_substitution.py
@@ -1,5 +1,4 @@
 import numpy as np
-import os
 
 from textattack.shared import utils
 from textattack.transformations.word_swap import WordSwap

--- a/textattack/transformations/word_swap_wordnet.py
+++ b/textattack/transformations/word_swap_wordnet.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from textattack.shared import utils
+from textattack.transformations.word_swap import WordSwap
+
+class WordSwapWordNet(WordSwap):
+    """ Transforms an input by replacing its words with synonyms provided by WordNet.
+    """
+
+    def _get_replacement_words(self, word, random=False):
+        """ Returns a list containing all possible words with 1 character replaced by a homoglyph.
+        """
+        synonyms = []
+        for syn in wordnet.synsets(word): 
+            for l in syn.lemmas(): 
+                synonyms.append(l.name()) 
+        print(f'word {word} has synonyms: {synonyms}')
+        return synonyms

--- a/textattack/transformations/word_swap_wordnet.py
+++ b/textattack/transformations/word_swap_wordnet.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-from textattack.shared import utils
+from nltk.corpus import wordnet
 from textattack.transformations.word_swap import WordSwap
 
 class WordSwapWordNet(WordSwap):
@@ -10,9 +8,8 @@ class WordSwapWordNet(WordSwap):
     def _get_replacement_words(self, word, random=False):
         """ Returns a list containing all possible words with 1 character replaced by a homoglyph.
         """
-        synonyms = []
+        synonyms = set()
         for syn in wordnet.synsets(word): 
             for l in syn.lemmas(): 
-                synonyms.append(l.name()) 
-        print(f'word {word} has synonyms: {synonyms}')
-        return synonyms
+                synonyms.add(l.name()) 
+        return list(synonyms)


### PR DESCRIPTION
transformation using synonyms derived from [WordNet](https://wordnet.princeton.edu/) via NLTK



--

I tried using WordNet as a drop-in replacement for the counterfitted nearest-neighbors substitution of textfooler. I attacked BERT on the MR dataset.

**original textfooler results**

```
┌───────────────────────────────┬────────┐
│ Attack Results                │        │
├───────────────────────────────┼────────┤
│ Number of successful attacks: │ 846    │
│ Number of failed attacks:     │ 5      │
│ Number of skipped attacks:    │ 149    │
│ Original accuracy:            │ 85.1%  │
│ Accuracy under attack:        │ 0.5%   │
│ Attack success rate:          │ 99.41% │
│ Average perturbed word %:     │ 14.74% │
│ Average num. words per input: │ 19.06  │
│ Avg num queries:              │ 140.76 │
└───────────────────────────────┴────────┘
```

**textfooler using the wordnet thesaurus substitution**
```
┌───────────────────────────────┬────────┐
│ Attack Results                │        │
├───────────────────────────────┼────────┤
│ Number of successful attacks: │ 313    │
│ Number of failed attacks:     │ 538    │
│ Number of skipped attacks:    │ 149    │
│ Original accuracy:            │ 85.1%  │
│ Accuracy under attack:        │ 53.8%  │
│ Attack success rate:          │ 36.78% │
│ Average perturbed word %:     │ 23.57% │
│ Average num. words per input: │ 19.06  │
│ Avg num queries:              │ 40.03  │
└───────────────────────────────┴────────┘
```

Looks like the attack with wordnet was a lot less successful, which makes sense– there are markedly fewer options to substitute each word with. I'm surprised the perturbed word % went up so much.
