### PR TITLE
Fix for file descriptor leak bug

### DIFF
--- a/textattack/constraints/semantics/word_embedding_distance.py
+++ b/textattack/constraints/semantics/word_embedding_distance.py
@@ -55,11 +55,13 @@ class WordEmbeddingDistance(Constraint):
         # Precomputed distance matrices store distances at mat[x][y], where
         # x and y are word IDs and x < y.
         if self.max_mse_dist is not None and os.path.exists(mse_dist_file):
-            self.mse_dist_mat = pickle.load(open(mse_dist_file, 'rb'))
+            with open(mse_dist_file, 'rb') as f:
+                self.mse_dist_mat = pickle.load(f)
         else:
             self.mse_dist_mat = {}
         if self.min_cos_sim is not None and os.path.exists(cos_sim_file):
-            self.cos_sim_mat = pickle.load(open(cos_sim_file, 'rb'))
+            with open(cos_sim_file, 'rb') as f:
+                self.cos_sim_mat = pickle.load(f)
         else:
             self.cos_sim_mat = {}
         

--- a/textattack/datasets/dataset.py
+++ b/textattack/datasets/dataset.py
@@ -38,7 +38,8 @@ class TextAttackDataset:
     def _load_pickle_file(self, file_name, offset=0):
         self.i = 0
         file_path = utils.download_if_needed(file_name)
-        self.examples = pickle.load( open(file_path, "rb" ) )
+        with open(file_path, "rb") as f:
+            self.examples = pickle.load(f)
         self.examples = self.examples[offset:]
     
     def _load_classification_text_file(self, text_file_name, offset=0):

--- a/textattack/shared/scripts/mturk_prep/se_thresh/gather_csv.py
+++ b/textattack/shared/scripts/mturk_prep/se_thresh/gather_csv.py
@@ -13,7 +13,8 @@ def main():
         if 'final.txt' not in run_files:
             continue
         args_path = os.path.join(run_path,'args.txt')
-        args_lines = open(args_path, 'r').readlines()
+        with open(args_path, 'r') as f:
+            args_lines = f.readlines()
         se_thresh_idx = args_lines[0].find('tf-adjusted') + len('tf-adjusted:')
         se_thresh = args_lines[0][se_thresh_idx:]
         se_thresh = se_thresh[:se_thresh.index(' ')]

--- a/textattack/shared/scripts/run_attack_parallel.py
+++ b/textattack/shared/scripts/run_attack_parallel.py
@@ -11,6 +11,8 @@ import tqdm
 from .run_attack_args_helper import *
 
 def set_env_variables(gpu_id):
+    # Set sharing strategy to file_system to avoid file descriptor leaks
+    torch.multiprocessing.set_sharing_strategy('file_system')
     # Only use one GPU, if we have one.
     if 'CUDA_VISIBLE_DEVICES' not in os.environ:
         os.environ['CUDA_VISIBLE_DEVICES'] = str(gpu_id)
@@ -22,8 +24,6 @@ def set_env_variables(gpu_id):
         os.environ['TFHUB_CACHE_DIR'] = os.path.expanduser('~/.cache/tensorflow-hub')
 
 def attack_from_queue(args, in_queue, out_queue):
-    # Set sharing strategy to file_system to avoid file descriptor leaks
-    torch.multiprocessing.set_sharing_strategy('file_system')
     gpu_id = torch.multiprocessing.current_process()._identity[0] - 2
     set_env_variables(gpu_id)
     _, attack = parse_goal_function_and_attack_from_args(args)

--- a/textattack/shared/scripts/run_attack_parallel.py
+++ b/textattack/shared/scripts/run_attack_parallel.py
@@ -7,7 +7,6 @@ import textattack
 import time
 import torch
 import tqdm
-import psutil
 
 from .run_attack_args_helper import *
 
@@ -80,7 +79,7 @@ def run(args):
     num_successes = 0
     pbar = tqdm.tqdm(total=args.num_examples, smoothing=0)
     while num_results < args.num_examples:
-        result = out_queue.get(block=True)   
+        result = out_queue.get(block=True)
         if isinstance(result, Exception):
             raise result
         attack_log_manager.log_result(result)

--- a/textattack/shared/utils.py
+++ b/textattack/shared/utils.py
@@ -264,5 +264,6 @@ def config(key):
     
 config_dict = {'CACHE_DIR': os.environ.get('TA_CACHE_DIR', os.path.expanduser('~/.cache/textattack'))}
 config_path = download_if_needed('config.yaml')
-config_dict.update(yaml.load(open(config_path, 'r'), Loader=yaml.FullLoader))
+with open(config_path, 'r') as f:
+    config_dict.update(yaml.load(f, Loader=yaml.FullLoader))
 _post_install_if_needed()

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -39,11 +39,13 @@ class WordEmbedding:
         # Precomputed distance matrices store distances at mat[x][y], where
         # x and y are word IDs and x < y.
         if os.path.exists(mse_dist_file):
-            self.mse_dist_mat = pickle.load(open(mse_dist_file, 'rb'))
+            with open(mse_dist_file, 'rb') as f:
+                self.mse_dist_mat = pickle.load(f)
         else:
             self.mse_dist_mat = {}
         if os.path.exists(cos_sim_file):
-            self.cos_sim_mat = pickle.load(open(cos_sim_file, 'rb'))
+            with open(cos_sim_file, 'rb') as f:
+                self.cos_sim_mat = pickle.load(f)
         else:
             self.cos_sim_mat = {}
     


### PR DESCRIPTION
When using Pytorch `multiprocessing` to share Tensors between processes, there's a pretty well documented [issue](https://github.com/pytorch/pytorch/issues/973) where file descriptors don't get closed properly, so when we hit file descriptor limit, our code breaks. This also happens with TextAttack, so I changed sharing strategy from `file_descriptor` to `file_system`. Also, changed some `open` expressions so that they're used within `with` (this wasn't the cause of the issue however). 