### PR TITLE
Add checkpoint feature for running long attacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ dist/
 
 # Weights & Biases outputs
 wandb/
+
+# checkpoints
+checkpoints/

--- a/textattack/goal_function_results/goal_function_result.py
+++ b/textattack/goal_function_results/goal_function_result.py
@@ -17,6 +17,9 @@ class GoalFunctionResult:
         
         if isinstance(self.score, torch.Tensor):
             self.score = self.score.item()
+
+        if isinstance(self.succeeded, torch.Tensor):
+            self.succeeded = self.succeeded.item()
     
     def get_text_color_input(self):
         """ A string representing the color this result's changed

--- a/textattack/loggers/file_logger.py
+++ b/textattack/loggers/file_logger.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import copy
 import terminaltables
 
 from .logger import Logger
@@ -7,6 +8,7 @@ from .logger import Logger
 class FileLogger(Logger):
     def __init__(self, filename='', stdout=False):
         self.stdout = stdout
+        self.filename = filename
         if stdout:
             self.fout = sys.stdout
         elif isinstance(filename, str):
@@ -17,6 +19,21 @@ class FileLogger(Logger):
         else:
             self.fout = filename
         self.num_results = 0
+
+    def __getstate__(self):
+        # Temporarily save file handle b/c we can't copy it
+        tmp = self.fout
+        self.fout = None
+        state = copy.deepcopy(self.__dict__)
+        self.fout = tmp
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        if self.stdout:
+            self.fout = sys.stdout
+        else:
+            self.fout = open(self.filename, 'a')
 
     def log_attack_result(self, result):
         self.num_results += 1

--- a/textattack/loggers/file_logger.py
+++ b/textattack/loggers/file_logger.py
@@ -22,10 +22,7 @@ class FileLogger(Logger):
 
     def __getstate__(self):
         # Temporarily save file handle b/c we can't copy it
-        tmp = self.fout
-        self.fout = None
-        state = copy.deepcopy(self.__dict__)
-        self.fout = tmp
+        state = {i: self.__dict__[i] for i in self.__dict__ if i !='fout'}
         return state
 
     def __setstate__(self, state):
@@ -53,4 +50,8 @@ class FileLogger(Logger):
 
     def log_sep(self):
         self.fout.write('-' * 90 + '\n')
+
+    def flush(self):
+        self.fout.flush()
+
         

--- a/textattack/loggers/visdom_logger.py
+++ b/textattack/loggers/visdom_logger.py
@@ -17,21 +17,19 @@ class VisdomLogger(Logger):
         if not port_is_open(port, hostname=hostname):
             raise socket.error(f'Visdom not running on {hostname}:{port}')
         self.vis = Visdom(port=port, server=hostname, env=env)
-        self.vis_args = {'port': port, 'server': hostname, 'env': env}
+        self.env = env
+        self.port = port
+        self.hostname = hostname
         self.windows = {}
         self.sample_rows = []
 
     def __getstate__(self):
-        # Temporarily save socket handle b/c we can't copy it
-        tmp = self.vis
-        self.vis = None
-        state = copy.deepcopy(self.__dict__)
-        self.vis = tmp
+        state = {i: self.__dict__[i] for i in self.__dict__ if i !='vis'}
         return state
 
     def __setstate__(self, state):
         self.__dict__ = state
-        self.vis = Visdom(**self.vis_args)
+        self.vis = Visdom(port=self.port, server=self.hostname, env=self.env)
 
     def log_attack_result(self, result):
         text_a, text_b = result.diff_color(color_method='html')

--- a/textattack/loggers/weights_and_biases_logger.py
+++ b/textattack/loggers/weights_and_biases_logger.py
@@ -5,8 +5,12 @@ from .logger import Logger
 
 class WeightsAndBiasesLogger(Logger):
     def __init__(self, filename='', stdout=False):
-        wandb.init(project='textattack')
+        wandb.init(project='textattack', resume=True)
         self._result_table_rows = []
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        wandb.init(project='textattack', resume=True)
 
     def log_summary_rows(self, rows, title, window_id):
         table = wandb.Table(columns=['Attack Results', ''])

--- a/textattack/search_methods/attack.py
+++ b/textattack/search_methods/attack.py
@@ -139,6 +139,10 @@ class Attack:
         
         if shuffle:
             random.shuffle(dataset.examples)
+
+        if num_examples <= 0:
+            return
+            yield
             
         for text, ground_truth_output in dataset:
             tokenized_text = TokenizedText(text, self.tokenizer)

--- a/textattack/shared/__init__.py
+++ b/textattack/shared/__init__.py
@@ -5,3 +5,4 @@ from . import validators
 
 from .tokenized_text import TokenizedText
 from .word_embedding import WordEmbedding
+from .checkpoint import CheckPoint

--- a/textattack/shared/__init__.py
+++ b/textattack/shared/__init__.py
@@ -5,4 +5,4 @@ from . import validators
 
 from .tokenized_text import TokenizedText
 from .word_embedding import WordEmbedding
-from .checkpoint import CheckPoint
+from .checkpoint import Checkpoint

--- a/textattack/shared/checkpoint.py
+++ b/textattack/shared/checkpoint.py
@@ -33,17 +33,26 @@ class CheckPoint:
 
         attack_logger_lines = []
         attack_logger_lines.append(utils.add_indent(
-            f'(Number of attacks performed: {self.results_count}', 2
+            f'(Total number of examples to attack): {self.args.num_examples}', 2
         ))
         attack_logger_lines.append(utils.add_indent(
-            f'(Number of successful attacks: {self.num_successful_attacks}', 2
+            f'(Number of attacks performed): {self.results_count}', 2
         ))
         attack_logger_lines.append(utils.add_indent(
-            f'(Number of failed attacks: {self.num_failed_attacks}', 2
+            f'(Number of remaining attacks): {self.num_remaining_attacks}', 2
         ))
-        attack_logger_lines.append(utils.add_indent(
-            f'(Number of skipped attacks: {self.num_skipped_attacks}', 2
+        breakdown_lines = []
+        breakdown_lines.append(utils.add_indent(
+            f'(Number of successful attacks): {self.num_successful_attacks}', 2
         ))
+        breakdown_lines.append(utils.add_indent(
+            f'(Number of failed attacks): {self.num_failed_attacks}', 2
+        ))
+        breakdown_lines.append(utils.add_indent(
+            f'(Number of skipped attacks): {self.num_skipped_attacks}', 2
+        ))
+        breakdown_str = utils.add_indent('\n' + '\n'.join(breakdown_lines), 2)
+        attack_logger_lines.append(utils.add_indent(f'(Latest result breakdown): {breakdown_str}', 2))
         attack_logger_str = utils.add_indent('\n' + '\n'.join(attack_logger_lines), 2)
         lines.append(utils.add_indent(f'(Previous attack summary):  {attack_logger_str}', 2))
 

--- a/textattack/shared/checkpoint.py
+++ b/textattack/shared/checkpoint.py
@@ -1,0 +1,119 @@
+import os
+import pickle
+import datetime
+from textattack.shared import utils
+from textattack.attack_results import SuccessfulAttackResult, FailedAttackResult, SkippedAttackResult
+
+class CheckPoint:
+    """ An object that stores necessary information for saving and loading checkpoints
+    
+        Args:
+            time (float): epoch time representing when checkpoint was made
+            args: command line arguments of the original attack
+            log_manager (AttackLogManager)
+    """
+    def __init__(self, time, args, log_manager):
+        self.time = time
+        self.args = args
+        self.log_manager = log_manager
+
+    def __repr__(self):
+        main_str = 'Checkpoint('
+        lines = []
+        lines.append(
+            utils.add_indent(f'(Time):  {self.datetime}', 2)
+        )
+
+        args_lines = []
+        for key in self.args.__dict__:
+            args_lines.append(utils.add_indent(f'({key}): {self.args.__dict__[key]}', 2))
+        args_str = utils.add_indent('\n' + '\n'.join(args_lines), 2)
+        
+        lines.append(utils.add_indent(f'(Args):  {args_str}', 2))
+
+        attack_logger_lines = []
+        attack_logger_lines.append(utils.add_indent(
+            f'(Number of attacks performed: {self.results_count}', 2
+        ))
+        attack_logger_lines.append(utils.add_indent(
+            f'(Number of successful attacks: {self.num_successful_attacks}', 2
+        ))
+        attack_logger_lines.append(utils.add_indent(
+            f'(Number of failed attacks: {self.num_failed_attacks}', 2
+        ))
+        attack_logger_lines.append(utils.add_indent(
+            f'(Number of skipped attacks: {self.num_skipped_attacks}', 2
+        ))
+        attack_logger_str = utils.add_indent('\n' + '\n'.join(attack_logger_lines), 2)
+        lines.append(utils.add_indent(f'(Previous attack summary):  {attack_logger_str}', 2))
+
+        main_str += '\n  ' + '\n  '.join(lines) + '\n'
+        main_str += ')'
+        return main_str
+    
+    __str__ = __repr__
+    
+    @property
+    def results_count(self):
+        """ Return number of attacks made so far """
+        return len(self.log_manager.results)
+    
+    @property
+    def num_skipped_attacks(self):
+        count = 0
+        for r in self.log_manager.results:
+            if isinstance(r, SkippedAttackResult):
+                count += 1
+        return count
+
+    @property
+    def num_failed_attacks(self):
+        count = 0
+        for r in self.log_manager.results:
+            if isinstance(r, FailedAttackResult):
+                count += 1
+        return count
+
+    @property
+    def num_successful_attacks(self):
+        count = 0
+        for r in self.log_manager.results:
+            if isinstance(r, SuccessfulAttackResult):
+                count += 1
+        return count
+
+    @property
+    def num_remaining_attacks(self):
+        if self.args.attack_n:
+            non_skipped_attacks = self.num_successful_attacks + self.num_failed_attacks 
+            count = self.args.num_examples - non_skipped_attacks
+        else:
+            count = self.args.num_examples - self.results_count
+        return count
+
+    @property
+    def dataset_offset(self):
+        """ Calculate offset into the dataset to start from """
+        # Original offset + # of results processed so far
+        return self.args.num_examples_offset + self.results_count
+
+    @property
+    def datetime(self):
+        return datetime.datetime.fromtimestamp(self.time).strftime('%Y-%m-%d %H:%M:%S')
+
+    def save(self):
+        file_name = "{}.ta.chkpt".format(int(self.time*1000))
+        if not os.path.exists(self.args.checkpoint_dir):
+            os.makedirs(self.args.checkpoint_dir)
+        path = os.path.join(self.args.checkpoint_dir, file_name)
+        with open(path, 'wb') as f:
+            pickle.dump(self, f)
+
+    @classmethod
+    def load(self, path):
+        with open(path, 'rb') as f:
+            checkpoint = pickle.load(f)
+        assert isinstance(checkpoint, CheckPoint)
+
+        return checkpoint
+        

--- a/textattack/shared/scripts/run_attack_args_helper.py
+++ b/textattack/shared/scripts/run_attack_args_helper.py
@@ -7,6 +7,7 @@ import textattack
 import time
 import torch
 import pickle
+import copy
 
 RECIPE_NAMES = {
     'alzantot':         'textattack.attack_recipes.Alzantot2018',
@@ -143,6 +144,7 @@ def set_seed(random_seed):
     torch.manual_seed(random_seed)
 
 def get_args():
+    # Parser for regular arguments
     parser = argparse.ArgumentParser(
         description='A commandline parser for TextAttack', 
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -150,7 +152,7 @@ def get_args():
     parser.add_argument('--transformation', type=str, required=False,
         default='word-swap-embedding', choices=TRANSFORMATION_CLASS_NAMES.keys(),
         help='The transformations to apply.')
-        
+
     parser.add_argument('--model', type=str, required=False, default='bert-yelp-sentiment',
         choices=MODEL_CLASS_NAMES.keys(), help='The classification model to attack.')
     
@@ -198,9 +200,6 @@ def get_args():
     def str_to_int(s): return sum((ord(c) for c in s))
     parser.add_argument('--random-seed', default=str_to_int('TEXTATTACK'))
 
-    parser.add_argument('--checkpoint-resume', required=False, type=str, 
-        help='Name of checkpoint file to resume attack from. If "latest" is entered, recover latest checkpoint. Overrides any oth')
-
     parser.add_argument('--checkpoint-dir', required=False, type=str, default=default_checkpoint_dir(),
         help='A directory to save/load checkpoint files.')
 
@@ -217,15 +216,36 @@ def get_args():
     attack_group.add_argument('--recipe', type=str, required=False, default=None,
         help='full attack recipe (overrides provided goal function, transformation & constraints)',
         choices=RECIPE_NAMES.keys())
-    
-    command_line_args = None if sys.argv[1:] else ['-h'] # Default to help with empty arguments.
-    args = parser.parse_args(command_line_args)
 
-    if args.checkpoint_interval and args.shuffle:
-        # Not allowed b/c we cannot recover order of shuffled data
-        raise ValueError('Cannot use `--checkpoint-interval` with `--shuffle=True`')
-    
-    set_seed(args.random_seed)
+    # Parser for parsing args for resume
+    resume_parser = argparse.ArgumentParser(
+        description='A commandline parser for TextAttack', 
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    resume_parser.add_argument('--checkpoint-file', '-f', type=str, required=False, default='latest', 
+        help='Name of checkpoint file to resume attack from. If "latest" is entered, recover latest checkpoint.')
+
+    resume_parser.add_argument('--checkpoint-dir', '-d', required=False, type=str, default=default_checkpoint_dir(),
+        help='A directory to save/load checkpoint files.')
+
+    resume_parser.add_argument('--checkpoint-interval', '-i', required=False, type=int, 
+        help='Interval for saving checkpoints. If not set, no checkpoints will be saved.')
+
+    resume_parser.add_argument('--parallel', action='store_true', default=False,
+        help='Run attack using multiple GPUs.')
+
+    if sys.argv[1:] and sys.argv[1].lower() == 'resume':
+        args = resume_parser.parse_args(sys.argv[2:])
+        setattr(args, 'checkpoint_resume', True)
+    else:
+        command_line_args = None if sys.argv[1:] else ['-h'] # Default to help with empty arguments.
+        args = parser.parse_args(command_line_args)
+        setattr(args, 'checkpoint_resume', False)
+
+        if args.checkpoint_interval and args.shuffle:
+            # Not allowed b/c we cannot recover order of shuffled data
+            raise ValueError('Cannot use `--checkpoint-interval` with `--shuffle=True`')
+        
+        set_seed(args.random_seed)
     
     return args
 
@@ -351,17 +371,17 @@ def parse_logger_from_args(args):# Create logger
     return attack_log_manager
 
 def parse_checkpoint_from_args(args):
-    if args.checkpoint_resume:
-        if args.checkpoint_resume.lower() == 'latest':
-            chkpt_files = [f for f in os.listdir(args.checkpoint_dir) if f.endswith('.ta.chkpt')]
-            latest_file = max(chkpt_files)
-            checkpoint_path = os.path.join(args.checkpoint_dir, latest_file)
-        else:
-            checkpoint_path = os.path.join(args.checkpoint_dir, args.checkpoint_resume)
-        
-        checkpoint = textattack.shared.CheckPoint.load(checkpoint_path) 
+    if args.checkpoint_file.lower() == 'latest':
+        chkpt_file_names = [f for f in os.listdir(args.checkpoint_dir) if f.endswith('.ta.chkpt')]
+        assert chkpt_file_names, "Checkpoint directory is empty"
+        timestamps = [int(f.replace('.ta.chkpt', '')) for f in chkpt_file_names]
+        latest_file = str(max(timestamps)) + '.ta.chkpt'
+        checkpoint_path = os.path.join(args.checkpoint_dir, latest_file)
     else:
-        checkpoint = None
+        checkpoint_path = os.path.join(args.checkpoint_dir, args.checkpoint_file)
+    
+    checkpoint = textattack.shared.Checkpoint.load(checkpoint_path)
+    set_seed(checkpoint.args.random_seed)
 
     return checkpoint
 
@@ -370,3 +390,15 @@ def default_checkpoint_dir():
     checkpoints_dir = os.path.join(current_dir, os.pardir, os.pardir, os.pardir, 'checkpoints')
     return os.path.normpath(checkpoints_dir)
 
+def merge_checkpoint_args(saved_args, cmdline_args):
+    """ Merge previously saved arguments for checkpoint and newly entered arguments """
+    args = copy.deepcopy(saved_args)
+    # Newly entered arguments take precedence
+    args.checkpoint_resume = cmdline_args.checkpoint_resume
+    args.parallel =  cmdline_args.parallel
+    args.checkpoint_dir = cmdline_args.checkpoint_dir
+    # If set, we replace
+    if cmdline_args.checkpoint_interval:
+        args.checkpoint_interval = cmdlineargs.checkpoint_interval
+    
+    return args


### PR DESCRIPTION
Add checkpoint feature so that users can save intermediate results when running attacks that take a long time on a large number of samples. This way, if process crashes for some reason, users can recover their results and continue to run the attack.

Added three command line arguments

- `--checkpoint-resume`: this takes the name of the checkpoint file (`*.ta.chkpt`) that users want to recover from. If set to "latest",  TextAttack automatically chooses latest saved checkpoint from checkpoint directory
- `--checkpoint-dir`: path of the checkpoint directory. This is where TextAttack will save checkpoint files and search for the files when loading. Default is set to `TextAttack/checkpoints`.
- `--checkpoint-interval`: the number of attacks TextAttack should process before saving checkpoint.

`CheckPoint` object is implemented so that is holds all the necessary contents required for recovering from stopped attacks.
Saves:

- Time of when checkpoint was created
- Args: Arguments of the original attack. This is used to recover models, transformations, constraints, etc. This is set once when starting a new run of TextAttack and should not be changed between recoveries. 
- AttackLogManager: Holds the results + information about loggers. Loggers have been modified to be pickleable(?). 
