### PR TITLE
fix non-change swaps

### DIFF
--- a/textattack/transformations/word_swap_wordnet.py
+++ b/textattack/transformations/word_swap_wordnet.py
@@ -11,7 +11,13 @@ class WordSwapWordNet(WordSwap):
         synonyms = set()
         for syn in wordnet.synsets(word): 
             for l in syn.lemmas():
-                if l.name() != word and not '_' in l.name():
+                if l.name() != word and check_if_one_word(l.name()):
                     # WordNet can suggest phrases that are joined by '_' but we ignore phrases.
                     synonyms.add(l.name()) 
         return list(synonyms)
+
+def check_if_one_word(word):
+    for c in word:
+        if not c.isalpha():
+            return False
+    return True

--- a/textattack/transformations/word_swap_wordnet.py
+++ b/textattack/transformations/word_swap_wordnet.py
@@ -10,6 +10,7 @@ class WordSwapWordNet(WordSwap):
         """
         synonyms = set()
         for syn in wordnet.synsets(word): 
-            for l in syn.lemmas(): 
-                synonyms.add(l.name()) 
+            for l in syn.lemmas():
+                if l.name() != word:
+                    synonyms.add(l.name()) 
         return list(synonyms)

--- a/textattack/transformations/word_swap_wordnet.py
+++ b/textattack/transformations/word_swap_wordnet.py
@@ -11,6 +11,7 @@ class WordSwapWordNet(WordSwap):
         synonyms = set()
         for syn in wordnet.synsets(word): 
             for l in syn.lemmas():
-                if l.name() != word:
+                if l.name() != word and not '_' in l.name():
+                    # WordNet can suggest phrases that are joined by '_' but we ignore phrases.
                     synonyms.add(l.name()) 
         return list(synonyms)


### PR DESCRIPTION
It's possible `l.name()` is actually same word as  `word`, in which case it's not a perturbation

It's also possible that `l.name()` actually suggests phrases joined by '_' or hyphenated compound words. Since most of them introduce new meaning, choose to ignore them. 