### PR TITLE
add fast tokenizer

### DIFF
--- a/textattack/tokenizers/auto_tokenizer.py
+++ b/textattack/tokenizers/auto_tokenizer.py
@@ -12,8 +12,8 @@ class AutoTokenizer(Tokenizer):
             https://github.com/huggingface/transformers/blob/master/src/transformers/tokenization_auto.py)
         max_seq_length: if set, will truncate & pad tokens to fit this length
     """
-    def __init__(self, name='bert-base-uncased', max_seq_length=None):
-        self.tokenizer = transformers.AutoTokenizer.from_pretrained(name)
+    def __init__(self, name='bert-base-uncased', max_seq_length=None, use_fast=True):
+        self.tokenizer = transformers.AutoTokenizer.from_pretrained(name, use_fast=use_fast)
         self.max_seq_length = max_seq_length
 
     def convert_text_to_tokens(self, input_text):


### PR DESCRIPTION
Fast Tokenizer is back again! Last time, I disabled it because `TokenizerFast` could not be pickled for multiprocessing. Not only is that issue now [fixed](https://github.com/huggingface/tokenizers/issues/87), but we don't even need to pickle it anymore since we clear tokenizer from `TokenizedText` to save memory in our worker process before sharing it with the main process (not sure why I didn't think of that before)

This should give us around 20~30% speed up. 