### PR TITLE
remove choices from parser

### DIFF
--- a/textattack/commands/attack/attack_args.py
+++ b/textattack/commands/attack/attack_args.py
@@ -242,6 +242,7 @@ CONSTRAINT_CLASS_NAMES = {
     #
     "repeat": "textattack.constraints.pre_transformation.RepeatModification",
     "stopword": "textattack.constraints.pre_transformation.StopwordModification",
+    "max-word-index": "textattack.constraints.pre_transformation.MaxWordIndexModification",
 }
 
 SEARCH_METHOD_CLASS_NAMES = {

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -30,7 +30,6 @@ def add_model_args(parser):
         type=str,
         required=False,
         default=None,
-        choices=model_names,
         help="The pre-trained model to attack.",
     )
     model_group.add_argument(

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -30,8 +30,8 @@ def add_model_args(parser):
         type=str,
         required=False,
         default=None,
-        help="The pre-trained model to attack. Usage: \"--model {model}:{arg_1}={value_1},{arg_2}={value_2}\". Choices: "
-            + str(model_names)",
+        help='The pre-trained model to attack. Usage: "--model {model}:{arg_1}={value_1},{arg_3}={value_3},...". Choices: '
+        + str(model_names),
     )
     model_group.add_argument(
         "--model-from-file",

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -30,7 +30,8 @@ def add_model_args(parser):
         type=str,
         required=False,
         default=None,
-        help="The pre-trained model to attack.",
+        help="The pre-trained model to attack. Usage: \"--model {model}:{arg_1}={value_1},{arg_2}={value_2}\". Choices: "
+            + str(model_names)",
     )
     model_group.add_argument(
         "--model-from-file",

--- a/textattack/commands/attack/attack_command.py
+++ b/textattack/commands/attack/attack_command.py
@@ -46,7 +46,6 @@ class AttackCommand(TextAttackCommand):
             type=str,
             required=False,
             default="word-swap-embedding",
-            choices=transformation_names,
             help='The transformation to apply. Usage: "--transformation {transformation}:{arg_1}={value_1},{arg_3}={value_3}. Choices: '
             + str(transformation_names),
         )

--- a/textattack/commands/attack/attack_command.py
+++ b/textattack/commands/attack/attack_command.py
@@ -46,7 +46,7 @@ class AttackCommand(TextAttackCommand):
             type=str,
             required=False,
             default="word-swap-embedding",
-            help='The transformation to apply. Usage: "--transformation {transformation}:{arg_1}={value_1},{arg_3}={value_3}. Choices: '
+            help='The transformation to apply. Usage: "--transformation {transformation}:{arg_1}={value_1},{arg_3}={value_3}". Choices: '
             + str(transformation_names),
         )
 

--- a/textattack/constraints/pre_transformation/__init__.py
+++ b/textattack/constraints/pre_transformation/__init__.py
@@ -1,4 +1,4 @@
 from .pre_transformation_constraint import PreTransformationConstraint
 from .stopword_modification import StopwordModification
 from .repeat_modification import RepeatModification
-from .max_length_modification import MaxLengthModification
+from .max_word_index_modification import MaxWordIndexModification

--- a/textattack/constraints/pre_transformation/max_word_index_modification.py
+++ b/textattack/constraints/pre_transformation/max_word_index_modification.py
@@ -2,7 +2,7 @@ from textattack.constraints.pre_transformation import PreTransformationConstrain
 from textattack.shared.utils import default_class_repr
 
 
-class MaxLengthModification(PreTransformationConstraint):
+class MaxWordIndexModification(PreTransformationConstraint):
     """ 
     A constraint disallowing the modification of words which are past some maximum length limit
     """


### PR DESCRIPTION
Having the `choices` keyword argument in parser prevents us from having command line args with arguments like `word-swap-embedding:max_candidates=20`.