### PR TITLE
add fix for genetic

### DIFF
--- a/textattack/search_methods/genetic_algorithm.py
+++ b/textattack/search_methods/genetic_algorithm.py
@@ -121,12 +121,24 @@ class GeneticAlgorithm(SearchMethod):
             new_text = x1_text.replace_words_at_indices(
                 indices_to_replace, words_to_replace
             )
-            new_text.attack_attrs["last_transformation"] = x1_text.attack_attrs[
-                "last_transformation"
-            ]
-            filtered = self.filter_transformations(
-                [new_text], x1_text, original_text=original_result.attacked_text
-            )
+            if "last_transformation" in x1_text.attack_attrs:
+                new_text.attack_attrs["last_transformation"] = x1_text.attack_attrs[
+                    "last_transformation"
+                ]
+                filtered = self.filter_transformations(
+                    [new_text], x1_text, original_text=original_result.attacked_text
+                )
+            elif "last_transformation" in x2_text.attack_attrs:
+                new_text.attack_attrs["last_transformation"] = x2_text.attack_attrs[
+                    "last_transformation"
+                ]
+                filtered = self.filter_transformations(
+                    [new_text], x1_text, original_text=original_result.attacked_text
+                )
+            else:
+                # In this case, neither x_1 nor x_2 has been transformed,
+                # meaning that new_text == original_text
+                filtered = [new_text]
 
             if filtered:
                 new_text = filtered[0]
@@ -170,9 +182,8 @@ class GeneticAlgorithm(SearchMethod):
         # Just b/c there are no candidates now doesn't mean we never want to select the word for perturbation
         # Therefore, we give small non-zero probability for words with no candidates
         # Epsilon is some small number to approximately assign 1% probability
-        total_candidates = np.sum(num_candidates_per_word)
-        num_zero_elements = len(words) - np.count_nonzero(num_candidates_per_word)
-        epsilon = max(1, int(total_candidates / (100 - num_zero_elements)))
+        num_total_candidates = np.sum(num_candidates_per_word)
+        epsilon = max(1, int(num_total_candidates * 0.01))
         for i in range(len(num_candidates_per_word)):
             if num_candidates_per_word[i] == 0:
                 num_candidates_per_word[i] = epsilon


### PR DESCRIPTION
I forgot some edge cases for genetic algorithm, like when for crossover, both parents are not perturbed. In that case, `last_transformation` doesn't exist in either of the parents' `attacked_text.attack_attrs`.

Also, simplify low probability assignment b/c whatever I had before actual make no sense and hurts when there are only a few transformations available. For example, if `num_zero_elements` is close to 100, then epsilon is big and we end up assigning way too high probability. 