### PR TITLE
Make sure seed is integer

### DIFF
--- a/textattack/commands/attack/attack_command.py
+++ b/textattack/commands/attack/attack_command.py
@@ -133,11 +133,7 @@ class AttackCommand(TextAttackCommand):
         def str_to_int(s):
             return sum((ord(c) for c in s))
 
-        parser.add_argument(
-            "--random-seed",
-            default=str_to_int("TEXTATTACK"),
-            type=int
-        )
+        parser.add_argument("--random-seed", default=str_to_int("TEXTATTACK"), type=int)
 
         parser.add_argument(
             "--checkpoint-dir",

--- a/textattack/commands/attack/attack_command.py
+++ b/textattack/commands/attack/attack_command.py
@@ -133,7 +133,11 @@ class AttackCommand(TextAttackCommand):
         def str_to_int(s):
             return sum((ord(c) for c in s))
 
-        parser.add_argument("--random-seed", default=str_to_int("TEXTATTACK"))
+        parser.add_argument(
+            "--random-seed",
+            default=str_to_int("TEXTATTACK"),
+            type=int
+        )
 
         parser.add_argument(
             "--checkpoint-dir",


### PR DESCRIPTION
Without the patch, I get the error below
```
textattack: First time running textattack: downloading remaining required packages.
textattack: Downloading NLTK required packages.
[nltk_data] Downloading package wordnet to /root/nltk_data...
[nltk_data]   Unzipping corpora/wordnet.zip.
[nltk_data] Downloading package averaged_perceptron_tagger to
[nltk_data]     /root/nltk_data...
[nltk_data]   Unzipping taggers/averaged_perceptron_tagger.zip.
[nltk_data] Downloading package universal_tagset to /root/nltk_data...
[nltk_data]   Unzipping taggers/universal_tagset.zip.
[nltk_data] Downloading package stopwords to /root/nltk_data...
[nltk_data]   Unzipping corpora/stopwords.zip.
2020-07-06 14:57:00.111904: I tensorflow/stream_executor/platform/default/dso_loader.cc:44] Successfully opened dynamic library libcudart.so.10.1
wandb: WARNING W&B installed but not logged in.  Run `wandb login` or set the WANDB_API_KEY env variable.
Traceback (most recent call last):
  File "_mt19937.pyx", line 178, in numpy.random._mt19937.MT19937._legacy_seeding
TypeError: 'str' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/textattack", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/dist-packages/textattack/commands/textattack_cli.py", line 41, in main
    args.func.run(args)
  File "/usr/local/lib/python3.6/dist-packages/textattack/commands/attack/attack_command.py", line 21, in run
    textattack.shared.utils.set_seed(args.random_seed)
  File "/usr/local/lib/python3.6/dist-packages/textattack/shared/utils/misc.py", line 90, in set_seed
    np.random.seed(random_seed)
  File "mtrand.pyx", line 243, in numpy.random.mtrand.RandomState.seed
  File "_mt19937.pyx", line 166, in numpy.random._mt19937.MT19937._legacy_seeding
  File "_mt19937.pyx", line 186, in numpy.random._mt19937.MT19937._legacy_seeding
TypeError: Cannot cast array from dtype('<U1') to dtype('int64') according to the rule 'safe'
```