### PR TITLE
augmentation updates, adversarial training

### DIFF
--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -75,7 +75,7 @@ class Augmenter:
         attacked_text = AttackedText(text)
         original_text = attacked_text
         all_transformed_texts = set()
-        num_words_to_swap = int(self.pct_words_to_swap * len(attacked_text.words))
+        num_words_to_swap = max(int(self.pct_words_to_swap * len(attacked_text.words)), 1)
         for _ in range(self.transformations_per_example):
             index_order = list(range(len(attacked_text.words)))
             random.shuffle(index_order)

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -137,3 +137,6 @@ class Augmenter:
             all_text_list.extend([text] + augmented_texts)
             all_id_list.extend([_id] * (1 + len(augmented_texts)))
         return all_text_list, all_id_list
+
+    def __repr__(self):
+        return type(self).__name__

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -3,7 +3,7 @@ import random
 import tqdm
 
 from textattack.constraints import PreTransformationConstraint
-from textattack.shared import AttackedText
+from textattack.shared import AttackedText, utils
 
 
 class Augmenter:
@@ -75,7 +75,9 @@ class Augmenter:
         attacked_text = AttackedText(text)
         original_text = attacked_text
         all_transformed_texts = set()
-        num_words_to_swap = max(int(self.pct_words_to_swap * len(attacked_text.words)), 1)
+        num_words_to_swap = max(
+            int(self.pct_words_to_swap * len(attacked_text.words)), 1
+        )
         for _ in range(self.transformations_per_example):
             index_order = list(range(len(attacked_text.words)))
             random.shuffle(index_order)
@@ -139,4 +141,20 @@ class Augmenter:
         return all_text_list, all_id_list
 
     def __repr__(self):
-        return type(self).__name__
+        main_str = "Augmenter" + "("
+        lines = []
+        # self.transformation
+        lines.append(utils.add_indent(f"(transformation):  {self.transformation}", 2))
+        # self.constraints
+        constraints_lines = []
+        constraints = self.constraints + self.pre_transformation_constraints
+        if len(constraints):
+            for i, constraint in enumerate(constraints):
+                constraints_lines.append(utils.add_indent(f"({i}): {constraint}", 2))
+            constraints_str = utils.add_indent("\n" + "\n".join(constraints_lines), 2)
+        else:
+            constraints_str = "None"
+        lines.append(utils.add_indent(f"(constraints): {constraints_str}", 2))
+        main_str += "\n  " + "\n  ".join(lines) + "\n"
+        main_str += ")"
+        return main_str

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -64,6 +64,9 @@ class EasyDataAugmenter(Augmenter):
         random.shuffle(augmented_text)
         return augmented_text[: self.transformations_per_example]
 
+    def __repr__(self):
+        return "EasyDataAugmenter"
+
 
 class SwapAugmenter(Augmenter):
     def __init__(self, **kwargs):

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -355,9 +355,13 @@ def parse_dataset_from_args(args):
             )
         model_train_args = json.loads(open(model_args_json_path).read())
         try:
+            if ":" in model_train_args["dataset"]:
+                name, subset = model_train_args["dataset"].split(":")
+            else:
+                name, subset = model_train_args["dataset"], None
             args.dataset_from_nlp = (
-                model_train_args["dataset"],
-                None,
+                name,
+                subset,
                 model_train_args["dataset_dev_split"],
             )
         except KeyError:

--- a/textattack/commands/train_model/run_training.py
+++ b/textattack/commands/train_model/run_training.py
@@ -453,13 +453,16 @@ def train_model(args):
     ):
         if adversarial_training:
             if epoch >= args.num_clean_epochs:
-                logger.info("Attacking model to generate new training set...")
-                adv_train_text = _generate_adversarial_examples(
-                    model, attackCls, list(zip(train_text, train_labels))
-                )
-                train_dataloader = _make_dataloader(
-                    tokenizer, adv_train_text, train_labels, args.batch_size
-                )
+                if (epoch - args.num_clean_epochs) % args.attack_period == 0:
+                    # only generate a new adversarial training set every args.attack_period epochs
+                    # after the clean epochs
+                    logger.info("Attacking model to generate new training set...")
+                    adv_train_text = _generate_adversarial_examples(
+                        model, attackCls, list(zip(train_text, train_labels))
+                    )
+                    train_dataloader = _make_dataloader(
+                        tokenizer, adv_train_text, train_labels, args.batch_size
+                    )
             else:
                 logger.info(f"Running clean epoch {epoch+1}/{args.num_clean_epochs}")
 

--- a/textattack/commands/train_model/train_args_helpers.py
+++ b/textattack/commands/train_model/train_args_helpers.py
@@ -136,13 +136,16 @@ def model_from_args(train_args, num_labels, model_path=None):
 def attack_from_args(args):
     # note that this returns a recipe type, not an object
     # (we need to wait to have access to the model to initialize)
-    attack_t = None
+    attackCls = None
     if args.attack:
         if args.attack in ATTACK_RECIPE_NAMES:
-            attack_t = eval(ATTACK_RECIPE_NAMES[args.attack])
+            attackCls = eval(ATTACK_RECIPE_NAMES[args.attack])
         else:
             raise ValueError(f"Unrecognized attack recipe: {args.attack}")
-    return attack_t
+
+    # check attack-related args
+    assert args.num_clean_epochs > 0, "--num-clean-epochs must be > 0"
+    return attackCls
 
 
 def augmenter_from_args(args):

--- a/textattack/commands/train_model/train_args_helpers.py
+++ b/textattack/commands/train_model/train_args_helpers.py
@@ -2,6 +2,7 @@ import os
 
 import textattack
 from textattack.commands.augment import AUGMENTATION_RECIPE_NAMES
+from textattack.commands.attack.attack_args import ATTACK_RECIPE_NAMES
 
 logger = textattack.shared.logger
 
@@ -130,6 +131,17 @@ def model_from_args(train_args, num_labels, model_path=None):
     model = model.to(textattack.shared.utils.device)
 
     return model
+
+def attack_from_args(args):
+    # note that this returns a recipe type, not an object
+    # (we need to wait to have access to the model to initialize)
+    attack_t = None
+    if args.attack:
+        if args.attack in ATTACK_RECIPE_NAMES:
+            attack_t = eval(ATTACK_RECIPE_NAMES[args.attack])
+        else:
+            raise ValueError(f"Unrecognized attack recipe: {args.attack}")
+    return attack_t
 
 
 def augmenter_from_args(args):

--- a/textattack/commands/train_model/train_args_helpers.py
+++ b/textattack/commands/train_model/train_args_helpers.py
@@ -1,8 +1,8 @@
 import os
 
 import textattack
-from textattack.commands.augment import AUGMENTATION_RECIPE_NAMES
 from textattack.commands.attack.attack_args import ATTACK_RECIPE_NAMES
+from textattack.commands.augment import AUGMENTATION_RECIPE_NAMES
 
 logger = textattack.shared.logger
 
@@ -131,6 +131,7 @@ def model_from_args(train_args, num_labels, model_path=None):
     model = model.to(textattack.shared.utils.device)
 
     return model
+
 
 def attack_from_args(args):
     # note that this returns a recipe type, not an object

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -49,6 +49,12 @@ class TrainModelCommand(TextAttackCommand):
             " ex: `glue:sst2` or `rotten_tomatoes`",
         )
         parser.add_argument(
+            "--pct-dataset",
+            type=float,
+            default=1.,
+            help="Fraction of dataset to use during training ([0., 1.])"
+        )
+        parser.add_argument(
             "--dataset-train-split",
             "--train-split",
             type=str,

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -109,6 +109,12 @@ class TrainModelCommand(TextAttackCommand):
             help="Number of epochs to train on the clean dataset before adversarial training (N/A if --attack unspecified)",
         )
         parser.add_argument(
+            "--attack-period",
+            type=int,
+            default=1,
+            help="How often (in epochs) to generate a new adversarial training set (N/A if --attack unspecified)",
+        )
+        parser.add_argument(
             "--augment", type=str, default=None, help="Augmentation recipe to use",
         )
         parser.add_argument(

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -14,7 +14,7 @@ class TrainModelCommand(TextAttackCommand):
 
     def run(self, args):
 
-        date_now = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M")
+        date_now = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f")
         current_dir = os.path.dirname(os.path.realpath(__file__))
         outputs_dir = os.path.join(
             current_dir, os.pardir, os.pardir, os.pardir, "outputs", "training"

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -51,8 +51,8 @@ class TrainModelCommand(TextAttackCommand):
         parser.add_argument(
             "--pct-dataset",
             type=float,
-            default=1.,
-            help="Fraction of dataset to use during training ([0., 1.])"
+            default=1.0,
+            help="Fraction of dataset to use during training ([0., 1.])",
         )
         parser.add_argument(
             "--dataset-train-split",
@@ -84,7 +84,7 @@ class TrainModelCommand(TextAttackCommand):
             help="save model after this many steps (-1 for no checkpointing)",
         )
         parser.add_argument(
-            "--checkpoint-every_epoch",
+            "--checkpoint-every-epoch",
             action="store_true",
             default=False,
             help="save model checkpoint after each epoch",
@@ -97,7 +97,10 @@ class TrainModelCommand(TextAttackCommand):
             help="Total number of epochs to train for",
         )
         parser.add_argument(
-            "--attack", type=str, default=None, help="Attack recipe to use (enables adversarial training)"
+            "--attack",
+            type=str,
+            default=None,
+            help="Attack recipe to use (enables adversarial training)",
         )
         parser.add_argument(
             "--augment", type=str, default=None, help="Augmentation recipe to use",

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -103,6 +103,12 @@ class TrainModelCommand(TextAttackCommand):
             help="Attack recipe to use (enables adversarial training)",
         )
         parser.add_argument(
+            "--num-clean-epochs",
+            type=int,
+            default=1,
+            help="Number of epochs to train on the clean dataset before adversarial training (N/A if --attack unspecified)",
+        )
+        parser.add_argument(
             "--augment", type=str, default=None, help="Augmentation recipe to use",
         )
         parser.add_argument(

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -91,6 +91,9 @@ class TrainModelCommand(TextAttackCommand):
             help="Total number of epochs to train for",
         )
         parser.add_argument(
+            "--attack", type=str, default=None, help="Attack recipe to use (enables adversarial training)"
+        )
+        parser.add_argument(
             "--augment", type=str, default=None, help="Augmentation recipe to use",
         )
         parser.add_argument(

--- a/textattack/shared/validators.py
+++ b/textattack/shared/validators.py
@@ -9,8 +9,7 @@ from . import logger
 # A list of goal functions and the corresponding available models.
 MODELS_BY_GOAL_FUNCTIONS = {
     (TargetedClassification, UntargetedClassification, InputReduction): [
-        r"^textattack.models.classification.*",
-        r"^textattack.models.entailment.*",
+        r"^textattack.models.lstm_for_classification.*",
         r"^transformers.modeling_\w*\.\w*ForSequenceClassification$",
     ],
     (NonOverlappingOutput,): [


### PR DESCRIPTION
Based on `textattack train --attack *recipe*`, TextAttack will run an attack against the current model at the beginning of each new training epoch, and use the resulting adversarial examples as training data for that epoch. This should improve robustness. Benchmarks coming soon.

Also allows for a combination of data augmentation and adversarial training (and fixes augmentation of eval set bug)