### PR TITLE
fix fast-alzantot recipe

### DIFF
--- a/textattack/commands/attack/run_attack_parallel.py
+++ b/textattack/commands/attack/run_attack_parallel.py
@@ -93,9 +93,18 @@ def run(args, checkpoint=None):
     in_queue = torch.multiprocessing.Queue()
     out_queue = torch.multiprocessing.Queue()
     # Add stuff to queue.
+    missing_datapoints = set()
     for i in worklist:
-        text, output = dataset[i]
-        in_queue.put((i, text, output))
+        try:
+            text, output = dataset[i]
+            in_queue.put((i, text, output))
+        except IndexError:
+            missing_datapoints.add(i)
+
+    # if our dataset is shorter than the number of samples chosen, remove the
+    # out-of-bounds indices from the dataset
+    for i in missing_datapoints:
+        worklist.remove(i)
 
     # Start workers.
     pool = torch.multiprocessing.Pool(
@@ -147,7 +156,7 @@ def run(args, checkpoint=None):
                 in_queue.put((worklist_tail, text, output))
             except IndexError:
                 raise IndexError(
-                    "Out of bounds access of dataset. Size of data is {} but tried to access index {}".format(
+                    "Tried adding to worklist, but ran out of datapoints. Size of data is {} but tried to access index {}".format(
                         len(dataset), worklist_tail
                     )
                 )

--- a/textattack/constraints/grammaticality/language_models/learning_to_write/language_model_helpers.py
+++ b/textattack/constraints/grammaticality/language_models/learning_to_write/language_model_helpers.py
@@ -52,6 +52,9 @@ class QueryHandler:
                         raw_idx_list[t].append(word_idxs[t])
             orig_num_idxs = len(raw_idx_list)
             raw_idx_list = [x for x in raw_idx_list if len(x)]
+            if not len(raw_idx_list):
+                # if no inputs are long enough to check, return inf for all
+                return [float("-inf")] * len(batch)
             num_idxs_dropped = orig_num_idxs - len(raw_idx_list)
             all_raw_idxs = torch.tensor(
                 raw_idx_list, device=self.device, dtype=torch.long

--- a/textattack/goal_functions/goal_function.py
+++ b/textattack/goal_functions/goal_function.py
@@ -34,7 +34,7 @@ class GoalFunction(ABC):
         use_cache=True,
         query_budget=float("inf"),
         model_batch_size=32,
-        model_cache_size=2 ** 18,
+        model_cache_size=2 ** 20,
     ):
         validators.validate_model_goal_function_compatibility(
             self.__class__, model.__class__

--- a/textattack/shared/attack.py
+++ b/textattack/shared/attack.py
@@ -38,7 +38,7 @@ class Attack:
         constraints=[],
         transformation=None,
         search_method=None,
-        constraint_cache_size=2 ** 18,
+        constraint_cache_size=2 ** 20,
     ):
         """ Initialize an attack object. Attacks can be run multiple times. """
         self.goal_function = goal_function
@@ -150,7 +150,7 @@ class Attack:
     ):
         """ 
         Filters a list of potential transformed texts based on ``self.constraints``\.
-        Checks cache first.
+        Utilizes an LRU cache to attempt to avoid recomputing common transformations.
             
         Args:
             transformed_texts: A list of candidate transformed ``AttackedText``\s to filter.


### PR DESCRIPTION
- bigger model & constraint cache sizes
- RNN doesn't try to predict in the [quite rare] case that it receives an empty tensor as input
- attacking w `--parallel` can handle dataset out-of-bounds errors