### PR TITLE
--save-last option for training

### DIFF
--- a/textattack/commands/train_model/run_training.py
+++ b/textattack/commands/train_model/run_training.py
@@ -552,6 +552,9 @@ def train_model(args):
         f"Eval of saved model {'pearson correlation' if args.do_regression else 'accuracy'}: {eval_score*100}%"
     )
 
+    if args.save_last:
+        _save_model(model, args.output_dir, args.weights_name, args.config_name)
+
     # end of training, save tokenizer
     try:
         tokenizer.save_pretrained(args.output_dir)

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -90,6 +90,12 @@ class TrainModelCommand(TextAttackCommand):
             help="save model checkpoint after each epoch",
         )
         parser.add_argument(
+            "--save-last",
+            action="store_true",
+            default=False,
+            help="Overwrite the saved model weights after the final epoch.",
+        )
+        parser.add_argument(
             "--num-train-epochs",
             "--epochs",
             type=int,

--- a/textattack/transformations/word_swap_gradient_based.py
+++ b/textattack/transformations/word_swap_gradient_based.py
@@ -106,7 +106,9 @@ class WordSwapGradientBased(Transformation):
                 break
 
         self.model.eval()
-        self.model.emb_layer.embedding.weight.requires_grad = self.model.emb_layer_trainable
+        self.model.emb_layer.embedding.weight.requires_grad = (
+            self.model.emb_layer_trainable
+        )
         return candidates
 
     def _call_model(self, text_ids):


### PR DESCRIPTION
quick change to the training code I was using to get the adversarial training results for the paper. `textattack train --save-last` saves the model weights to disk after the last epoch, instead of only preserving the highest eval acc. When adversarial training you're often more interested in the robustness of the model after a specific number of epochs, not in getting the highest possible eval acc
.