### PR TITLE
Model agnosticism

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ textattack attack --model distilbert-base-uncased-qqp --recipe deepwordbug --num
 *Beam search with beam width 4 and word embedding transformation and untargeted goal function on an LSTM*:
 ```bash
 textattack attack --model lstm-mr --num-examples 20 \
- --search-method beam-search:beam_width=4 --transformation word-swap-embedding \
- --constraints repeat stopword max-words-perturbed:max_num_words=2 embedding:min_cos_sim=0.8 part-of-speech \
+ --search-method beam-search|beam_width=4 --transformation word-swap-embedding \
+ --constraints repeat stopword max-words-perturbed|max_num_words=2 embedding|min_cos_sim=0.8 part-of-speech \
  --goal-function untargeted-classification
 ```
 
@@ -214,7 +214,7 @@ This uses the `EasyDataAugmenter` recipe to augment the `rotten_tomatoes` datase
 
 *Fine-Tune `bert-base` on the `CoLA` dataset for 5 epochs**:
 ```bash
-textattack train --model bert-base-uncased --dataset glue:cola --batch-size 32 --epochs 5
+textattack train --model bert-base-uncased --dataset glue|cola --batch-size 32 --epochs 5
 ```
 
 ### `textattack peek-dataset`
@@ -260,7 +260,7 @@ and datasets from the [`nlp` package](https://github.com/huggingface/nlp)! Here'
 and attacking a pre-trained model and dataset:
 
 ```bash
-textattack attack --model-from-huggingface distilbert-base-uncased-finetuned-sst-2-english --dataset-from-nlp glue:sst2 --recipe deepwordbug --num-examples 10
+textattack attack --model-from-huggingface distilbert-base-uncased-finetuned-sst-2-english --dataset-from-nlp glue|sst2 --recipe deepwordbug --num-examples 10
 ```
 
 You can explore other pre-trained models using the `--model-from-huggingface` argument, or other datasets by changing 

--- a/docs/quickstart/command_line_usage.md
+++ b/docs/quickstart/command_line_usage.md
@@ -63,12 +63,12 @@ The heart of textattack is running adversarial attacks on NLP models with
 1. Use an **attack recipe** to launch an attack from the literature: `textattack attack --recipe deepwordbug`
 2. Build your attack from components: 
 ```
-textattack attack --model lstm-mr --num-examples 20 --search-method beam-search:beam_width=4 \
+textattack attack --model lstm-mr --num-examples 20 --search-method beam-search|beam_width=4 \
 --transformation word-swap-embedding \
---constraints repeat stopword max-words-perturbed:max_num_words=2 embedding:min_cos_sim=0.8 part-of-speech \
+--constraints repeat stopword max-words-perturbed|max_num_words=2 embedding|min_cos_sim=0.8 part-of-speech \
 --goal-function untargeted-classification
 ```
-3. Create a python file that builds your attack and load it: `textattack attack --attack-from-file my_file.py:my_attack_name`
+3. Create a python file that builds your attack and load it: `textattack attack --attack-from-file my_file.py|my_attack_name`
 
 ## Training Models with `textattack train`
 
@@ -130,6 +130,6 @@ whatever dataset you're working with. Whether you're loading a dataset of your
 own from a file, or one from NLP, you can use `textattack peek-dataset` to 
 see some basic information about the dataset.
 
-For example, use `textattack peek-dataset --dataset-from-nlp glue:mrpc` to see
+For example, use `textattack peek-dataset --dataset-from-nlp glue|mrpc` to see
 information about the MRPC dataset (from the GLUE set of datasets). This will
 print statistics like the number of labels, average number of words, etc.

--- a/tests/sample_inputs/sst_model_and_dataset.py
+++ b/tests/sample_inputs/sst_model_and_dataset.py
@@ -7,6 +7,8 @@ model_path = "distilbert-base-uncased-finetuned-sst-2-english"
 tokenizer = textattack.models.tokenizers.AutoTokenizer(model_path)
 model = transformers.AutoModelForSequenceClassification.from_pretrained(model_path)
 
+model = textattack.models.wrappers.HuggingFaceModelWrapper(model, tokenizer)
+
 dataset = textattack.datasets.HuggingFaceNlpDataset(
     "glue", subset="sst2", split="train", shuffle=False
 )

--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -85,7 +85,7 @@ class TestAttackedText:
         assert attacked_text_pair.printable_text() == desired_printed_pair_text
 
     def test_tokenizer_input(self, attacked_text, attacked_text_pair):
-        assert attacked_text.tokenizer_input == (raw_text,)
+        assert attacked_text.tokenizer_input == raw_text
         assert attacked_text_pair.tokenizer_input == (premise, hypothesis)
 
     def test_word_replacement(self, attacked_text):

--- a/tests/test_command_line/test_attack.py
+++ b/tests/test_command_line/test_attack.py
@@ -18,7 +18,7 @@ attack_test_params = [
         "attack_from_file",
         (
             "textattack attack --model cnn-imdb "
-            "--attack-from-file tests/sample_inputs/attack_from_file.py:Attack "
+            "--attack-from-file tests/sample_inputs/attack_from_file.py|Attack "
             "--num-examples 2  --num-examples-offset 18 --attack-n "
             "--shuffle=False"
         ),
@@ -43,7 +43,7 @@ attack_test_params = [
         (
             "textattack attack --model-from-huggingface "
             "distilbert-base-uncased-finetuned-sst-2-english "
-            "--dataset-from-nlp glue:sst2:train --recipe deepwordbug --num-examples 3 "
+            "--dataset-from-nlp glue|sst2|train --recipe deepwordbug --num-examples 3 "
             "--shuffle=False"
         ),
         "tests/sample_outputs/run_attack_transformers_nlp.txt",
@@ -92,9 +92,9 @@ attack_test_params = [
     (
         "run_attack_targeted_mnli_misc",
         (
-            "textattack attack --attack-n --goal-function targeted-classification:target_class=2 "
+            "textattack attack --attack-n --goal-function targeted-classification|target_class=2 "
             "--enable-csv --model bert-base-uncased-mnli --num-examples 2 --attack-n --transformation word-swap-wordnet "
-            "--constraints lang-tool repeat stopword --search beam-search:beam_width=2 --shuffle=False"
+            "--constraints lang-tool repeat stopword --search beam-search|beam_width=2 --shuffle=False"
         ),
         "tests/sample_outputs/run_attack_targetedclassification2_wordnet_langtool_enable_csv_beamsearch2_attack_n.txt",
     ),
@@ -107,7 +107,7 @@ attack_test_params = [
         "run_attack_flair_pos_tagger_bert_score",
         (
             "textattack attack --model bert-base-uncased-mr --search greedy-word-wir --transformation word-swap-embedding "
-            "--constraints repeat stopword bert-score:min_bert_score=0.8 part-of-speech:tagger_type=\\'flair\\' "
+            "--constraints repeat stopword bert-score|min_bert_score=0.8 part-of-speech|tagger_type=\\'flair\\' "
             "--num-examples 4 --num-examples-offset 10 --shuffle=False"
         ),
         "tests/sample_outputs/run_attack_flair_pos_tagger_bert_score.txt",

--- a/textattack/commands/attack/attack_args.py
+++ b/textattack/commands/attack/attack_args.py
@@ -128,6 +128,10 @@ HUGGINGFACE_DATASET_BY_MODEL = {
         "textattack/distilbert-base-uncased-MNLI",
         ("glue", "mnli", "validation_matched", [1, 2, 0]),
     ),
+    "distilbert-base-uncased-mr": (
+        "textattack/distilbert-base-uncased-rotten-tomatoes",
+        ("rotten_tomatoes", None, "test"),
+    ),
     "distilbert-base-uncased-mrpc": (
         "textattack/distilbert-base-uncased-MRPC",
         ("glue", "mrpc", "validation"),

--- a/textattack/commands/attack/attack_args.py
+++ b/textattack/commands/attack/attack_args.py
@@ -1,5 +1,3 @@
-# import textattack
-
 ATTACK_RECIPE_NAMES = {
     "alzantot": "textattack.attack_recipes.GeneticAlgorithmAlzantot2018",
     "bae": "textattack.attack_recipes.BAEGarg2019",

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -303,9 +303,18 @@ def parse_model_from_args(args):
         model = textattack.shared.utils.load_textattack_model_from_path(
             args.model, model_path
         )
-        model = textattack.models.wrappers.PyTorchModelWrapper(
-            model, model.tokenizer, batch_size=args.model_batch_size
-        )
+        # Choose the approprate model wrapper (based on whether or not this is
+        # a HuggingFace model).
+        if isinstance(
+            model, textattack.models.helpers.BERTForClassification
+        ) or isinstance(model, textattack.models.helpers.T5ForTextToText):
+            model = textattack.models.wrappers.HuggingFaceModelWrapper(
+                model, model.tokenizer, batch_size=args.model_batch_size
+            )
+        else:
+            model = textattack.models.wrappers.PyTorchModelWrapper(
+                model, model.tokenizer, batch_size=args.model_batch_size
+            )
     elif args.model and os.path.exists(args.model):
         # Support loading TextAttack-trained models via just their folder path.
         # If `args.model` is a path/directory, let's assume it was a model

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -118,15 +118,14 @@ def load_module_from_file(file_path):
     return module
 
 
-def parse_transformation_from_args(args, model):
-    # Transformations
+def parse_transformation_from_args(args, model_wrapper):
     transformation_name = args.transformation
     if ARGS_SPLIT_TOKEN in transformation_name:
         transformation_name, params = transformation_name.split(ARGS_SPLIT_TOKEN)
 
         if transformation_name in WHITE_BOX_TRANSFORMATION_CLASS_NAMES:
             transformation = eval(
-                f"{WHITE_BOX_TRANSFORMATION_CLASS_NAMES[transformation_name]}(model, {params})"
+                f"{WHITE_BOX_TRANSFORMATION_CLASS_NAMES[transformation_name]}(model_wrapper.model, {params})"
             )
         elif transformation_name in BLACK_BOX_TRANSFORMATION_CLASS_NAMES:
             transformation = eval(
@@ -137,7 +136,7 @@ def parse_transformation_from_args(args, model):
     else:
         if transformation_name in WHITE_BOX_TRANSFORMATION_CLASS_NAMES:
             transformation = eval(
-                f"{WHITE_BOX_TRANSFORMATION_CLASS_NAMES[transformation_name]}(model)"
+                f"{WHITE_BOX_TRANSFORMATION_CLASS_NAMES[transformation_name]}(model_wrapper.model)"
             )
         elif transformation_name in BLACK_BOX_TRANSFORMATION_CLASS_NAMES:
             transformation = eval(
@@ -149,7 +148,6 @@ def parse_transformation_from_args(args, model):
 
 
 def parse_goal_function_from_args(args, model):
-    # Goal Functions
     goal_function = args.goal_function
     if ARGS_SPLIT_TOKEN in goal_function:
         goal_function_name, params = goal_function.split(ARGS_SPLIT_TOKEN)
@@ -169,7 +167,6 @@ def parse_goal_function_from_args(args, model):
 
 
 def parse_constraints_from_args(args):
-    # Constraints
     if not args.constraints:
         return []
 
@@ -266,11 +263,10 @@ def parse_model_from_args(args):
                 f"``{model_name}`` not found in module {args.model_from_file}"
             )
 
-        if not isinstance(model, textattack.models.ModelWrapper):
+        if not isinstance(model, textattack.models.wrappers.ModelWrapper):
             raise TypeError(
-                f"Model must be of type "
-                "``textattack.models.ModelWrapper``, got type "
-                "{type(model)}"
+                "Model must be of type "
+                f"``textattack.models.ModelWrapper``, got type {type(model)}"
             )
     elif (args.model in HUGGINGFACE_DATASET_BY_MODEL) or args.model_from_huggingface:
         # Support loading models automatically from the HuggingFace model hub.

--- a/textattack/commands/attack/attack_args_helpers.py
+++ b/textattack/commands/attack/attack_args_helpers.py
@@ -18,6 +18,9 @@ from .attack_args import (
     WHITE_BOX_TRANSFORMATION_CLASS_NAMES,
 )
 
+# The split token allows users to optionally pass multiple arguments in a single
+# parameter by separating them with the split token.
+ARGS_SPLIT_TOKEN = "|"
 
 def add_model_args(parser):
     """Adds model-related arguments to an argparser.
@@ -117,8 +120,8 @@ def load_module_from_file(file_path):
 def parse_transformation_from_args(args, model):
     # Transformations
     transformation_name = args.transformation
-    if ":" in transformation_name:
-        transformation_name, params = transformation_name.split(":")
+    if ARGS_SPLIT_TOKEN in transformation_name:
+        transformation_name, params = transformation_name.split(ARGS_SPLIT_TOKEN)
 
         if transformation_name in WHITE_BOX_TRANSFORMATION_CLASS_NAMES:
             transformation = eval(
@@ -147,8 +150,8 @@ def parse_transformation_from_args(args, model):
 def parse_goal_function_from_args(args, model):
     # Goal Functions
     goal_function = args.goal_function
-    if ":" in goal_function:
-        goal_function_name, params = goal_function.split(":")
+    if ARGS_SPLIT_TOKEN in goal_function:
+        goal_function_name, params = goal_function.split(ARGS_SPLIT_TOKEN)
         if goal_function_name not in GOAL_FUNCTION_CLASS_NAMES:
             raise ValueError(f"Error: unsupported goal_function {goal_function_name}")
         goal_function = eval(
@@ -171,8 +174,8 @@ def parse_constraints_from_args(args):
 
     _constraints = []
     for constraint in args.constraints:
-        if ":" in constraint:
-            constraint_name, params = constraint.split(":")
+        if ARGS_SPLIT_TOKEN in constraint:
+            constraint_name, params = constraint.split(ARGS_SPLIT_TOKEN)
             if constraint_name not in CONSTRAINT_CLASS_NAMES:
                 raise ValueError(f"Error: unsupported constraint {constraint_name}")
             _constraints.append(
@@ -189,8 +192,8 @@ def parse_constraints_from_args(args):
 def parse_attack_from_args(args):
     model = parse_model_from_args(args)
     if args.recipe:
-        if ":" in args.recipe:
-            recipe_name, params = args.recipe.split(":")
+        if ARGS_SPLIT_TOKEN in args.recipe:
+            recipe_name, params = args.recipe.split(ARGS_SPLIT_TOKEN)
             if recipe_name not in ATTACK_RECIPE_NAMES:
                 raise ValueError(f"Error: unsupported recipe {recipe_name}")
             recipe = eval(f"{ATTACK_RECIPE_NAMES[recipe_name]}(model, {params})")
@@ -204,8 +207,8 @@ def parse_attack_from_args(args):
         recipe.constraint_cache_size = args.constraint_cache_size
         return recipe
     elif args.attack_from_file:
-        if ":" in args.attack_from_file:
-            attack_file, attack_name = args.attack_from_file.split(":")
+        if ARGS_SPLIT_TOKEN in args.attack_from_file:
+            attack_file, attack_name = args.attack_from_file.split(ARGS_SPLIT_TOKEN)
         else:
             attack_file, attack_name = args.attack_from_file, "attack"
         attack_module = load_module_from_file(attack_file)
@@ -219,8 +222,8 @@ def parse_attack_from_args(args):
         goal_function = parse_goal_function_from_args(args, model)
         transformation = parse_transformation_from_args(args, model)
         constraints = parse_constraints_from_args(args)
-        if ":" in args.search:
-            search_name, params = args.search.split(":")
+        if ARGS_SPLIT_TOKEN in args.search:
+            search_name, params = args.search.split(ARGS_SPLIT_TOKEN)
             if search_name not in SEARCH_METHOD_CLASS_NAMES:
                 raise ValueError(f"Error: unsupported search {search_name}")
             search_method = eval(f"{SEARCH_METHOD_CLASS_NAMES[search_name]}({params})")
@@ -245,8 +248,8 @@ def parse_model_from_args(args):
         textattack.shared.logger.info(
             f"Loading model and tokenizer from file: {colored_model_name}"
         )
-        if ":" in args.model_from_file:
-            model_file, model_name, tokenizer_name = args.model_from_file.split(":")
+        if ARGS_SPLIT_TOKEN in args.model_from_file:
+            model_file, model_name, tokenizer_name = args.model_from_file.split(ARGS_SPLIT_TOKEN)
         else:
             _, model_name, tokenizer_name = (
                 args.model_from_file,
@@ -280,7 +283,7 @@ def parse_model_from_args(args):
             else args.model_from_huggingface
         )
 
-        if ":" in model_name:
+        if ARGS_SPLIT_TOKEN in model_name:
             model_class, model_name = model_name
             model_class = eval(f"transformers.{model_class}")
         else:
@@ -360,8 +363,8 @@ def parse_dataset_from_args(args):
             )
         model_train_args = json.loads(open(model_args_json_path).read())
         try:
-            if ":" in model_train_args["dataset"]:
-                name, subset = model_train_args["dataset"].split(":")
+            if ARGS_SPLIT_TOKEN in model_train_args["dataset"]:
+                name, subset = model_train_args["dataset"].split(ARGS_SPLIT_TOKEN)
             else:
                 name, subset = model_train_args["dataset"], None
             args.dataset_from_nlp = (
@@ -379,8 +382,8 @@ def parse_dataset_from_args(args):
         textattack.shared.logger.info(
             f"Loading model and tokenizer from file: {args.model_from_file}"
         )
-        if ":" in args.dataset_from_file:
-            dataset_file, dataset_name = args.dataset_from_file.split(":")
+        if ARGS_SPLIT_TOKEN in args.dataset_from_file:
+            dataset_file, dataset_name = args.dataset_from_file.split(ARGS_SPLIT_TOKEN)
         else:
             dataset_file, dataset_name = args.dataset_from_file, "dataset"
         try:
@@ -398,8 +401,8 @@ def parse_dataset_from_args(args):
     elif args.dataset_from_nlp:
         dataset_args = args.dataset_from_nlp
         if isinstance(dataset_args, str):
-            if ":" in dataset_args:
-                dataset_args = dataset_args.split(":")
+            if ARGS_SPLIT_TOKEN in dataset_args:
+                dataset_args = dataset_args.split(ARGS_SPLIT_TOKEN)
             else:
                 dataset_args = (dataset_args,)
         dataset = textattack.datasets.HuggingFaceNlpDataset(

--- a/textattack/commands/textattack_cli.py
+++ b/textattack/commands/textattack_cli.py
@@ -9,9 +9,6 @@ from textattack.commands.list_things import ListThingsCommand
 from textattack.commands.peek_dataset import PeekDatasetCommand
 from textattack.commands.train_model import TrainModelCommand
 
-# import os
-# import sys
-
 
 def main():
     parser = argparse.ArgumentParser(

--- a/textattack/commands/train_model/train_args_helpers.py
+++ b/textattack/commands/train_model/train_args_helpers.py
@@ -101,6 +101,8 @@ def model_from_args(train_args, num_labels, model_path=None):
         )
         if model_path:
             model.load_from_disk(model_path)
+
+        model = textattack.models.wrappers.PyTorchModelWrapper(model, model.tokenizer)
     elif train_args.model == "cnn":
         textattack.shared.logger.info(
             "Loading textattack model: WordCNNForClassification"

--- a/textattack/commands/train_model/train_args_helpers.py
+++ b/textattack/commands/train_model/train_args_helpers.py
@@ -112,6 +112,8 @@ def model_from_args(train_args, num_labels, model_path=None):
         )
         if model_path:
             model.load_from_disk(model_path)
+
+        model = textattack.models.wrappers.PyTorchModelWrapper(model, model.tokenizer)
     else:
         import transformers
 
@@ -127,9 +129,8 @@ def model_from_args(train_args, num_labels, model_path=None):
         tokenizer = textattack.models.tokenizers.AutoTokenizer(
             train_args.model, use_fast=True, max_length=train_args.max_length
         )
-        setattr(model, "tokenizer", tokenizer)
 
-    model = model.to(textattack.shared.utils.device)
+        model = textattack.models.wrappers.HuggingFaceModelWrapper(model, tokenizer)
 
     return model
 

--- a/textattack/constraints/grammaticality/language_models/google_language_model/alzantot_goog_lm.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/alzantot_goog_lm.py
@@ -4,7 +4,6 @@
 """
 import os
 
-# from google.protobuf import text_format
 import lru
 import numpy as np
 import tensorflow as tf
@@ -12,9 +11,6 @@ import tensorflow as tf
 from textattack.shared import utils
 
 from . import lm_data_utils, lm_utils
-
-# import sys
-
 
 tf.get_logger().setLevel("INFO")
 

--- a/textattack/constraints/grammaticality/language_models/google_language_model/google_language_model.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/google_language_model.py
@@ -7,8 +7,6 @@ from textattack.transformations import WordSwap
 
 from .alzantot_goog_lm import GoogLMHelper
 
-# import time
-
 
 class GoogleLanguageModel(Constraint):
     """Constraint that uses the Google 1 Billion Words Language Model to

--- a/textattack/constraints/semantics/bert_score.py
+++ b/textattack/constraints/semantics/bert_score.py
@@ -12,8 +12,6 @@ import bert_score
 from textattack.constraints import Constraint
 from textattack.shared import utils
 
-# import nltk
-
 
 class BERTScore(Constraint):
     """

--- a/textattack/constraints/semantics/sentence_encoders/infer_sent/infer_sent.py
+++ b/textattack/constraints/semantics/sentence_encoders/infer_sent/infer_sent.py
@@ -1,9 +1,7 @@
 import os
 
-# import numpy as np
 import torch
 
-# from textattack.constraints import Constraint
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder
 from textattack.shared import utils
 

--- a/textattack/constraints/semantics/sentence_encoders/sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/sentence_encoder.py
@@ -6,8 +6,6 @@ import torch
 from textattack.constraints import Constraint
 from textattack.shared import utils
 
-# import os
-
 
 class SentenceEncoder(Constraint):
     """Constraint using cosine similarity between sentence encodings of x and

--- a/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/universal_sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/universal_sentence_encoder.py
@@ -1,6 +1,3 @@
-# import os
-
-# import tensorflow as tf
 import tensorflow_hub as hub
 
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder

--- a/textattack/goal_functions/classification/classification_goal_function.py
+++ b/textattack/goal_functions/classification/classification_goal_function.py
@@ -25,8 +25,8 @@ class ClassificationGoalFunction(GoalFunction):
         # Ensure the returned value is now a tensor.
         if not isinstance(scores, torch.Tensor):
             raise TypeError(
-                f"Must have list, np.ndarray, or torch.Tensor of "
-                "scores. Got type {type(scores)}"
+                "Must have list, np.ndarray, or torch.Tensor of "
+                f"scores. Got type {type(scores)}"
             )
 
         # Validation check on model score dimensions

--- a/textattack/goal_functions/classification/classification_goal_function.py
+++ b/textattack/goal_functions/classification/classification_goal_function.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 
 from textattack.goal_function_results import ClassificationGoalFunctionResult
@@ -17,10 +18,21 @@ class ClassificationGoalFunction(GoalFunction):
         This is a task-dependent operation. For example, classification
         outputs need to have a softmax applied.
         """
+        # Automatically cast a list or ndarray of predictions to a tensor.
+        if isinstance(scores, list) or isinstance(scores, np.ndarray):
+            scores = torch.tensor(scores)
+
+        # Ensure the returned value is now a tensor.
+        if not isinstance(scores, torch.Tensor):
+            raise TypeError(
+                f"Must have list, np.ndarray, or torch.Tensor of "
+                "scores. Got type {type(scores)}"
+            )
+
         # Validation check on model score dimensions
         if scores.ndim == 1:
             # Unsqueeze prediction, if it's been squeezed by the model.
-            if len(inputs == 1):
+            if len(inputs) == 1:
                 scores = scores.unsqueeze(dim=0)
             else:
                 raise ValueError(

--- a/textattack/goal_functions/goal_function.py
+++ b/textattack/goal_functions/goal_function.py
@@ -148,6 +148,10 @@ class GoalFunction(ABC):
 
         outputs = self.model(inputs)
 
+        assert len(inputs) == len(
+            outputs
+        ), f"Got {len(outputs)} outputs for {len(inputs)} inputs"
+
         return self._process_model_outputs(attacked_text_list, outputs)
 
     def _call_model(self, attacked_text_list):

--- a/textattack/goal_functions/text/text_to_text_goal_function.py
+++ b/textattack/goal_functions/text/text_to_text_goal_function.py
@@ -14,11 +14,8 @@ class TextToTextGoalFunction(GoalFunction):
         return TextToTextGoalFunctionResult
 
     def _process_model_outputs(self, _, outputs):
-        """Processes and validates a list of model outputs.
-
-        Flatten list of lists to a single list.
-        """
-        return [output for batch in outputs for output in batch]
+        """Processes and validates a list of model outputs."""
+        return outputs.flatten()
 
     def _get_displayed_output(self, raw_output):
         return raw_output

--- a/textattack/loggers/attack_log_manager.py
+++ b/textattack/loggers/attack_log_manager.py
@@ -4,8 +4,6 @@ from textattack.attack_results import FailedAttackResult, SkippedAttackResult
 
 from . import CSVLogger, FileLogger, VisdomLogger, WeightsAndBiasesLogger
 
-# import torch
-
 
 class AttackLogManager:
     """Logs the results of an attack to all attached loggers."""

--- a/textattack/loggers/file_logger.py
+++ b/textattack/loggers/file_logger.py
@@ -1,4 +1,3 @@
-# import copy
 import os
 import sys
 

--- a/textattack/loggers/visdom_logger.py
+++ b/textattack/loggers/visdom_logger.py
@@ -1,4 +1,3 @@
-# import copy
 import socket
 
 from visdom import Visdom

--- a/textattack/models/__init__.py
+++ b/textattack/models/__init__.py
@@ -1,2 +1,3 @@
 from . import helpers
 from . import tokenizers
+from . import wrappers

--- a/textattack/models/helpers/t5_for_text_to_text.py
+++ b/textattack/models/helpers/t5_for_text_to_text.py
@@ -1,10 +1,11 @@
+import torch
 import transformers
 
 from textattack.models.tokenizers import T5Tokenizer
 from textattack.shared import utils
 
 
-class T5ForTextToText:
+class T5ForTextToText(torch.nn.Module):
     """A T5 model trained to generate text from text.
 
     For more information, please see the T5 paper, "Exploring the Limits of
@@ -29,6 +30,7 @@ class T5ForTextToText:
     def __init__(
         self, mode="english_to_german", max_length=20, num_beams=1, early_stopping=True
     ):
+        super().__init__()
         self.model = transformers.AutoModelForSeq2SeqLM.from_pretrained("t5-base")
         self.model.to(utils.device)
         self.model.eval()

--- a/textattack/models/tokenizers/auto_tokenizer.py
+++ b/textattack/models/tokenizers/auto_tokenizer.py
@@ -1,7 +1,4 @@
-# import torch
 import transformers
-
-# from textattack.shared import AttackedText
 
 
 class AutoTokenizer:

--- a/textattack/models/wrappers/__init__.py
+++ b/textattack/models/wrappers/__init__.py
@@ -1,3 +1,5 @@
+from .model_wrapper import ModelWrapper
+
 from .huggingface_model_wrapper import HuggingFaceModelWrapper
 from .pytorch_model_wrapper import PyTorchModelWrapper
 from .sklearn_model_wrapper import SklearnModelWrapper

--- a/textattack/models/wrappers/__init__.py
+++ b/textattack/models/wrappers/__init__.py
@@ -1,0 +1,4 @@
+from .huggingface_model_wrapper import HuggingFaceModelWrapper
+from .pytorch_model_wrapper import PyTorchModelWrapper
+from .sklearn_model_wrapper import SklearnModelWrapper
+from .tensorflow_model_wrapper import TensorFlowModelWrapper

--- a/textattack/models/wrappers/huggingface_model_wrapper.py
+++ b/textattack/models/wrappers/huggingface_model_wrapper.py
@@ -27,7 +27,17 @@ class HuggingFaceModelWrapper(PyTorchModelWrapper):
                 for k, v in input_dict.items()
             }
             outputs = self.model(**input_dict)
-            return outputs[0]
+
+            if isinstance(outputs[0], str):
+                # HuggingFace sequence-to-sequence models return a list of
+                # string predictions as output. In this case, return the full
+                # list of outputs.
+                return outputs
+            else:
+                # HuggingFace classification models return a tuple as output
+                # where the first item in the tuple corresponds to the list of
+                # scores for each input.
+                return outputs[0]
 
         with torch.no_grad():
             outputs = textattack.shared.utils.batch_model_predict(

--- a/textattack/models/wrappers/huggingface_model_wrapper.py
+++ b/textattack/models/wrappers/huggingface_model_wrapper.py
@@ -1,0 +1,37 @@
+import torch
+
+import textattack
+
+from .pytorch_model_wrapper import PyTorchModelWrapper
+
+
+class HuggingFaceModelWrapper(PyTorchModelWrapper):
+    """Loads a HuggingFace ``transformers`` model and tokenizer."""
+
+    def __call__(self, text_input_list):
+        """Passes inputs to HuggingFace models as keyword arguments.
+
+        (Regular PyTorch ``nn.Module`` models typically take inputs as
+        positional arguments.)
+        """
+        ids = self.tokenize(text_input_list)
+
+        def model_predict(inputs):
+            """Turn a list of dicts into a dict of lists.
+
+            Then make lists (values of dict) into tensors.
+            """
+            input_dict = {k: [_dict[k] for _dict in inputs] for k in inputs[0]}
+            input_dict = {
+                k: torch.tensor(v).to(textattack.shared.utils.device)
+                for k, v in input_dict.items()
+            }
+            outputs = self.model(**input_dict)
+            return outputs[0]
+
+        with torch.no_grad():
+            outputs = textattack.shared.utils.batch_model_predict(
+                model_predict, ids, batch_size=self.batch_size
+            )
+
+        return outputs

--- a/textattack/models/wrappers/model_wrapper.py
+++ b/textattack/models/wrappers/model_wrapper.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+
+
+class ModelWrapper(ABC):
+    """A model wrapper queries a model with a list of text inputs.
+
+    Classification-based models return a list of lists, where each sublist
+    represents the model's scores for a given input.
+
+    Text-to-text models return a list of strings, where each string is the
+    output – like a translation or summarization – for a given input.
+    """
+
+    @abstractmethod
+    def __call__(self, text_list):
+        raise NotImplementedError()

--- a/textattack/models/wrappers/pytorch_model_wrapper.py
+++ b/textattack/models/wrappers/pytorch_model_wrapper.py
@@ -1,0 +1,45 @@
+import torch
+
+import textattack
+
+from .model_wrapper import ModelWrapper
+
+
+class PyTorchModelWrapper(ModelWrapper):
+    """Loads a PyTorch model (`nn.Module`) and tokenizer."""
+
+    # TODO test training code before putting up PR
+    def __init__(self, model, tokenizer, batch_size=32):
+        if not isinstance(model, torch.nn.Module):
+            raise TypeError(
+                f"PyTorch model must be torch.nn.Module, got type {type(model)}"
+            )
+
+        self.model = model.to(textattack.shared.utils.device)
+        self.tokenizer = tokenizer
+        self.batch_size = batch_size
+
+    @property
+    def get_model_device(self):
+        if hasattr(self.model, "model"):
+            model_device = next(self.model.model.parameters()).device
+        else:
+            model_device = next(self.model.parameters()).device
+        return model_device
+
+    def tokenize(self, inputs):
+        if hasattr(self.tokenizer, "batch_encode"):
+            return self.tokenizer.batch_encode(inputs)
+        else:
+            return [self.tokenizer.encode(x) for x in inputs]
+
+    def __call__(self, text_input_list):
+        ids = self.tokenize(text_input_list)
+        ids = torch.tensor(ids).to(textattack.shared.utils.device)
+
+        with torch.no_grad():
+            outputs = textattack.shared.utils.batch_model_predict(
+                self.model, ids, batch_size=self.batch_size
+            )
+
+        return outputs

--- a/textattack/models/wrappers/pytorch_model_wrapper.py
+++ b/textattack/models/wrappers/pytorch_model_wrapper.py
@@ -8,7 +8,6 @@ from .model_wrapper import ModelWrapper
 class PyTorchModelWrapper(ModelWrapper):
     """Loads a PyTorch model (`nn.Module`) and tokenizer."""
 
-    # TODO test training code before putting up PR
     def __init__(self, model, tokenizer, batch_size=32):
         if not isinstance(model, torch.nn.Module):
             raise TypeError(
@@ -18,14 +17,6 @@ class PyTorchModelWrapper(ModelWrapper):
         self.model = model.to(textattack.shared.utils.device)
         self.tokenizer = tokenizer
         self.batch_size = batch_size
-
-    @property
-    def get_model_device(self):
-        if hasattr(self.model, "model"):
-            model_device = next(self.model.model.parameters()).device
-        else:
-            model_device = next(self.model.parameters()).device
-        return model_device
 
     def tokenize(self, inputs):
         if hasattr(self.tokenizer, "batch_encode"):

--- a/textattack/models/wrappers/sklearn_model_wrapper.py
+++ b/textattack/models/wrappers/sklearn_model_wrapper.py
@@ -1,0 +1,19 @@
+import textattack
+
+from .model_wrapper import ModelWrapper
+
+
+class SklearnModelWrapper(ModelWrapper):
+    """Loads an sklearn model and tokenizer."""
+
+    def __init__(self, model, tokenizer):
+        raise NotImplementedError()
+
+        self.model = model.to(textattack.shared.utils.device)
+        self.tokenizer = tokenizer
+
+    def tokenize(self, text_input_list):
+        raise NotImplementedError()
+
+    def __call__(self, text_input_list):
+        raise NotImplementedError()

--- a/textattack/models/wrappers/tensorflow_model_wrapper.py
+++ b/textattack/models/wrappers/tensorflow_model_wrapper.py
@@ -1,0 +1,19 @@
+import textattack
+
+from .model_wrapper import ModelWrapper
+
+
+class TensorFlowModelWrapper(ModelWrapper):
+    """Loads a TensorFlow model and tokenizer."""
+
+    def __init__(self, model, tokenizer):
+        raise NotImplementedError()
+
+        self.model = model.to(textattack.shared.utils.device)
+        self.tokenizer = tokenizer
+
+    def tokenize(self, text_input_list):
+        raise NotImplementedError()
+
+    def __call__(self, text_input_list):
+        raise NotImplementedError()

--- a/textattack/shared/attack.py
+++ b/textattack/shared/attack.py
@@ -165,9 +165,15 @@ class Attack:
             original_text: The original ``AttackedText`` from which the attack started.
         """
         # Remove any occurences of current_text in transformed_texts
+        original_num_texts = len(transformed_texts)
         transformed_texts = [
             t for t in transformed_texts if t.text != current_text.text
         ]
+        if len(transformed_texts) < original_num_texts:
+            # If this happened, warn the user
+            utils.logger.warn(
+                "Warning: transformation returned text with no changes. Skipping."
+            )
         # Populate cache with transformed_texts
         uncached_texts = []
         for transformed_text in transformed_texts:

--- a/textattack/shared/attack.py
+++ b/textattack/shared/attack.py
@@ -164,6 +164,10 @@ class Attack:
             current_text: The current ``AttackedText`` on which the transformation was applied.
             original_text: The original ``AttackedText`` from which the attack started.
         """
+        # Remove any occurences of current_text in transformed_texts
+        transformed_texts = [
+            t for t in transformed_texts if t.text != current_text.text
+        ]
         # Populate cache with transformed_texts
         uncached_texts = []
         for transformed_text in transformed_texts:

--- a/textattack/shared/attack.py
+++ b/textattack/shared/attack.py
@@ -13,8 +13,6 @@ from textattack.attack_results import (
 from textattack.goal_function_results import GoalFunctionResultStatus
 from textattack.shared import AttackedText, utils
 
-# import os
-
 
 class Attack:
     """An attack generates adversarial examples on text.

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -346,7 +346,11 @@ class AttackedText:
     @property
     def tokenizer_input(self):
         """The tuple of inputs to be passed to the tokenizer."""
-        return tuple(self._text_input.values())
+        input_tuple = tuple(self._text_input.values())
+        # Prefer to return a string instead of a tuple with a single value.
+        if len(input_tuple) == 1:
+            input_tuple = input_tuple[0]
+        return input_tuple
 
     @property
     def column_labels(self):

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -349,8 +349,9 @@ class AttackedText:
         input_tuple = tuple(self._text_input.values())
         # Prefer to return a string instead of a tuple with a single value.
         if len(input_tuple) == 1:
-            input_tuple = input_tuple[0]
-        return input_tuple
+            return input_tuple[0]
+        else:
+            return input_tuple
 
     @property
     def column_labels(self):

--- a/textattack/shared/utils/misc.py
+++ b/textattack/shared/utils/misc.py
@@ -1,4 +1,3 @@
-# import importlib
 import json
 import os
 import random
@@ -57,26 +56,33 @@ def html_table_from_rows(rows, title=None, header=None, style_dict=None):
     return table_html
 
 
-def load_textattack_model_from_path(model_name, model_path):
-    """Loads a pre-trained TextAttack model from its name and path."""
+def get_textattack_model_num_labels(model_name, model_path):
+    """Reads `train_args.json` and gets the number of labels for a trained
+    model, if present."""
+    model_cache_path = textattack.shared.utils.download_if_needed(model_path)
+    train_args_path = os.path.join(model_cache_path, "train_args.json")
+    if not os.path.exists(train_args_path):
+        textattack.shared.logger.warn(
+            f"train_args.json not found in model path {model_path}. Defaulting to 2 labels."
+        )
+        return 2
+    else:
+        args = json.loads(open(train_args_path).read())
+        return args["num_labels"]
 
-    def get_num_labels():
-        model_cache_path = textattack.shared.utils.download_if_needed(model_path)
-        train_args_path = os.path.join(model_cache_path, "train_args.json")
-        if not os.path.exists(train_args_path):
-            textattack.shared.logger.warn(
-                f"train_args.json not found in model path {model_path}. Defaulting to 2 labels."
-            )
-            return 2
-        else:
-            args = json.loads(open(train_args_path).read())
-            return args["num_labels"]
+
+def load_textattack_model_from_path(model_name, model_path):
+    """Loads a pre-trained TextAttack model from its name and path.
+
+    For example, model_name "lstm-yelp" and model path
+    "models/classification/lstm/yelp".
+    """
 
     colored_model_name = textattack.shared.utils.color_text(
         model_name, color="blue", method="ansi"
     )
     if model_name.startswith("lstm"):
-        num_labels = get_num_labels()
+        num_labels = get_textattack_model_num_labels(model_name, model_path)
         textattack.shared.logger.info(
             f"Loading pre-trained TextAttack LSTM: {colored_model_name}"
         )
@@ -84,7 +90,7 @@ def load_textattack_model_from_path(model_name, model_path):
             model_path=model_path, num_labels=num_labels
         )
     elif model_name.startswith("cnn"):
-        num_labels = get_num_labels()
+        num_labels = get_textattack_model_num_labels(model_name, model_path)
         textattack.shared.logger.info(
             f"Loading pre-trained TextAttack CNN: {colored_model_name}"
         )

--- a/textattack/shared/utils/misc.py
+++ b/textattack/shared/utils/misc.py
@@ -68,7 +68,7 @@ def get_textattack_model_num_labels(model_name, model_path):
         return 2
     else:
         args = json.loads(open(train_args_path).read())
-        return args["num_labels"]
+        return args.get("num_labels", 2)
 
 
 def load_textattack_model_from_path(model_name, model_path):

--- a/textattack/shared/utils/tensor.py
+++ b/textattack/shared/utils/tensor.py
@@ -1,119 +1,19 @@
 import torch
 
-import textattack
 
-# from textattack.shared import utils
+def batch_model_predict(model_predict, inputs, batch_size=32):
+    """Runs prediction on iterable ``inputs`` using batch size ``batch_size``.
 
-
-def batch_tokenize(tokenizer, attacked_text_list):
-    """Tokenizes a list of inputs and returns their tokenized forms in a
-    list."""
-    inputs = [at.tokenizer_input for at in attacked_text_list]
-    if hasattr(tokenizer, "batch_encode"):
-        return tokenizer.batch_encode(inputs)
-    else:
-        return [tokenizer.encode(x) for x in inputs]
-
-
-def batch_model_predict(model, inputs, batch_size=32):
+    Aggregates all predictions into an ``np.ndarray``.
+    """
     outputs = []
     i = 0
     while i < len(inputs):
         batch = inputs[i : i + batch_size]
-        batch_preds = model_predict(model, batch)
+        batch_preds = model_predict(batch)
+        if not isinstance(batch_preds, torch.Tensor):
+            batch_preds = torch.Tensor(batch_preds)
         outputs.append(batch_preds)
         i += batch_size
-    try:
-        return torch.cat(outputs, dim=0)
-    except TypeError:
-        # A TypeError occurs when the lists in ``outputs`` are full of strings
-        # instead of numbers. If this is the case, just return the regular
-        # list.
-        return outputs
 
-
-def get_model_device(model):
-    if hasattr(model, "model"):
-        model_device = next(model.model.parameters()).device
-    else:
-        model_device = next(model.parameters()).device
-    return model_device
-
-
-def model_predict(model, inputs):
-    try:
-        return try_model_predict(model, inputs)
-    except Exception as e:
-        textattack.shared.utils.logger.error(
-            f"Failed to predict with model {model.__class__}. Check tokenizer configuration."
-        )
-        raise e
-
-
-def try_model_predict(model, inputs):
-    model_device = get_model_device(model)
-
-    if isinstance(inputs, torch.Tensor):
-        # If `inputs` is a tensor, we'll assume it's been pre-processed, and send
-        # it to the model.
-        if model_device != inputs.device:
-            inputs = inputs.to(model_device)
-        outputs = model(inputs)
-
-    elif isinstance(inputs, dict):
-        # If `inputs` is a single dict, its values are assumed to be input
-        # tensors.
-        outputs = model(**inputs)
-
-    elif isinstance(inputs[0], dict):
-        # If ``inputs`` is a list of dicts, we convert them to a single dict
-        # (now of tensors) and pass to the model as kwargs.
-        # Convert list of dicts to dict of lists.
-        input_dict = {k: [_dict[k] for _dict in inputs] for k in inputs[0]}
-        # Convert list keys to tensors.
-        for key in input_dict:
-            input_dict[key] = pad_lists(input_dict[key])
-            input_dict[key] = torch.tensor(input_dict[key]).to(model_device)
-        # Do inference using keys as kwargs.
-        outputs = model(**input_dict)
-
-    else:
-        # If ``inputs`` is not a list of dicts, it's either a list of tuples
-        # (model takes multiple inputs) or a list of ID lists (where the model
-        # takes a single input). In this case, we'll do our best to figure out
-        # the proper input to the model, anyway.
-        input_dim = get_list_dim(inputs)
-
-        if input_dim == 2:
-            # For models where the input is a single vector.
-            inputs = pad_lists(inputs)
-            inputs = torch.tensor(inputs).to(model_device)
-            outputs = model(inputs)
-        elif input_dim == 3:
-            # For models that take multiple vectors per input.
-            inputs = map(list, zip(*inputs))
-            inputs = map(pad_lists, inputs)
-            inputs = (torch.tensor(x).to(model_device) for x in inputs)
-            outputs = model(*inputs)
-        else:
-            raise TypeError(f"Error: malformed inputs.ndim ({input_dim})")
-
-    # If `outputs` is a tuple, take the first argument.
-    if isinstance(outputs, tuple):
-        outputs = outputs[0]
-    return outputs
-
-
-def get_list_dim(ids):
-    if isinstance(ids, tuple) or isinstance(ids, list) or isinstance(ids, torch.Tensor):
-        return 1 + get_list_dim(ids[0])
-    else:
-        return 0
-
-
-def pad_lists(lists, pad_token=0):
-    """Pads lists with trailing zeros to make them all the same length."""
-    max_list_len = max(len(list) for list in lists)
-    for i in range(len(lists)):
-        lists[i] += [pad_token] * (max_list_len - len(lists[i]))
-    return lists
+    return torch.cat(outputs, dim=0)

--- a/textattack/shared/utils/tensor.py
+++ b/textattack/shared/utils/tensor.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 
 
@@ -11,9 +12,20 @@ def batch_model_predict(model_predict, inputs, batch_size=32):
     while i < len(inputs):
         batch = inputs[i : i + batch_size]
         batch_preds = model_predict(batch)
-        if not isinstance(batch_preds, torch.Tensor):
-            batch_preds = torch.Tensor(batch_preds)
+
+        # Some seq-to-seq models will return a single string as a prediction
+        # for a single-string list. Wrap these in a list.
+        if isinstance(batch_preds, str):
+            batch_preds = [batch_preds]
+
+        # Get PyTorch tensors off of other devices.
+        if isinstance(batch_preds, torch.Tensor):
+            batch_preds = batch_preds.cpu()
+
+        # Cast all predictions iterables to ``np.ndarray`` types.
+        if not isinstance(batch_preds, np.ndarray):
+            batch_preds = np.array(batch_preds)
         outputs.append(batch_preds)
         i += batch_size
 
-    return torch.cat(outputs, dim=0)
+    return np.concatenate(outputs, axis=0)

--- a/textattack/shared/validators.py
+++ b/textattack/shared/validators.py
@@ -1,4 +1,3 @@
-# import collections
 import re
 
 import textattack

--- a/textattack/transformations/composite_transformation.py
+++ b/textattack/transformations/composite_transformation.py
@@ -1,5 +1,3 @@
-# import numpy as np
-
 from textattack.shared import utils
 from textattack.transformations.transformation import Transformation
 

--- a/textattack/transformations/word_swap.py
+++ b/textattack/transformations/word_swap.py
@@ -3,9 +3,6 @@ import string
 
 from .transformation import Transformation
 
-# import nltk
-# from nltk.corpus import stopwords
-
 
 class WordSwap(Transformation):
     """An abstract class that takes a sentence and transforms it by replacing

--- a/textattack/transformations/word_swap_gradient_based.py
+++ b/textattack/transformations/word_swap_gradient_based.py
@@ -23,30 +23,29 @@ class WordSwapGradientBased(Transformation):
         # Unwrap model wrappers. Need raw model for gradient.
         if not isinstance(model_wrapper, textattack.models.wrappers.ModelWrapper):
             raise TypeError(f"Got invalid model wrapper type {type(model_wrapper)}")
-        model = model_wrapper.model
+        self.model = model_wrapper.model
         self.model_wrapper = model_wrapper
-        self.model = model
+        self.tokenizer = self.model_wrapper.tokenizer
         # Make sure we know how to compute the gradient for this model.
-        validate_model_gradient_word_swap_compatibility(model)
+        validate_model_gradient_word_swap_compatibility(self.model)
         # Make sure this model has all of the required properties.
-        if not hasattr(model, "word_embeddings"):
+        if not hasattr(self.model, "word_embeddings"):
             raise ValueError(
                 "Model needs word embedding matrix for gradient-based word swap"
             )
-        if not hasattr(model, "lookup_table"):
+        if not hasattr(self.model, "lookup_table"):
             raise ValueError("Model needs lookup table for gradient-based word swap")
-        if not hasattr(model, "zero_grad"):
+        if not hasattr(self.model, "zero_grad"):
             raise ValueError("Model needs `zero_grad()` for gradient-based word swap")
-        if not hasattr(model_wrapper.tokenizer, "convert_id_to_word"):
+        if not hasattr(self.tokenizer, "convert_id_to_word"):
             raise ValueError(
                 "Tokenizer needs `convert_id_to_word()` for gradient-based word swap"
             )
-        if not hasattr(model_wrapper.tokenizer, "pad_id"):
+        if not hasattr(self.tokenizer, "pad_id"):
             raise ValueError("Tokenizer needs `pad_id` for gradient-based word swap")
-        if not hasattr(model_wrapper.tokenizer, "oov_id"):
+        if not hasattr(self.tokenizer, "oov_id"):
             raise ValueError("Tokenizer needs `oov_id` for gradient-based word swap")
         self.loss = torch.nn.CrossEntropyLoss()
-        self.model = model
         self.pad_id = self.model_wrapper.tokenizer.pad_id
         self.oov_id = self.model_wrapper.tokenizer.oov_id
         self.top_n = top_n
@@ -67,7 +66,7 @@ class WordSwapGradientBased(Transformation):
         lookup_table_transpose = lookup_table.transpose(0, 1)
 
         # get word IDs
-        text_ids = self.model_wrapper.tokenizer.encode(attacked_text.tokenizer_input)
+        text_ids = self.tokenizer.encode(attacked_text.tokenizer_input)
 
         # set backward hook on the word embeddings for input x
         emb_hook = Hook(self.model.word_embeddings, backward=True)
@@ -95,7 +94,7 @@ class WordSwapGradientBased(Transformation):
             diffs[j] = b_grads - a_grad
 
         # Don't change to the pad token.
-        diffs[:, self.model_wrapper.tokenizer.pad_id] = float("-inf")
+        diffs[:, self.tokenizer.pad_id] = float("-inf")
 
         # Find best indices within 2-d tensor by flattening.
         word_idxs_sorted_by_grad = (-diffs).flatten().argsort()
@@ -106,7 +105,7 @@ class WordSwapGradientBased(Transformation):
             idx_in_diffs = idx // num_words_in_vocab
             idx_in_vocab = idx % (num_words_in_vocab)
             idx_in_sentence = indices_to_replace[idx_in_diffs]
-            word = self.model_wrapper.tokenizer.convert_id_to_word(idx_in_vocab)
+            word = self.tokenizer.convert_id_to_word(idx_in_vocab)
             if (not utils.has_letter(word)) or (len(utils.words_from_text(word)) != 1):
                 # Do not consider words that are solely letters or punctuation.
                 continue

--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -35,7 +35,7 @@ class WordSwapInflections(WordSwap):
 
     def _get_transformations(self, current_text, indices_to_modify):
         words = current_text.words
-        sentence = Sentence(current_text.text)
+        sentence = Sentence(" ".join(words))
         self._flair_pos_tagger.predict(sentence)
         word_list, pos_list = zip_flair_result(sentence)
 

--- a/textattack/transformations/word_swap_masked_lm.py
+++ b/textattack/transformations/word_swap_masked_lm.py
@@ -1,6 +1,5 @@
 import itertools
 
-# import numpy as np
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
 

--- a/textattack/transformations/word_swap_qwerty.py
+++ b/textattack/transformations/word_swap_qwerty.py
@@ -1,4 +1,3 @@
-# import copy
 import random
 
 from textattack.transformations.word_swap import WordSwap


### PR DESCRIPTION
- change ":" in command-line API to "|" (should hopefully make paths work on Windows)
- add back `distilbert-base-uncased-mr` model
- remove commented-out imports all over the place
- remove `try_model_predict` and other messy PyTorch model prediction guessing
- create `ModelWrapper` abstract class that models can implement to be used for attacks (this will allow us to add models from TensorFlow, sklearn, etc. with ease)