### PR TITLE
parallel fix; add --check-robustness training option

### DIFF
--- a/textattack/commands/attack/run_attack_single_threaded.py
+++ b/textattack/commands/attack/run_attack_single_threaded.py
@@ -24,6 +24,18 @@ def run(args, checkpoint=None):
     # Disable tensorflow logs, except in the case of an error.
     if "TF_CPP_MIN_LOG_LEVEL" not in os.environ:
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
+    # Fix TensorFlow GPU memory growth
+    import tensorflow as tf
+
+    gpus = tf.config.experimental.list_physical_devices("GPU")
+    if gpus:
+        try:
+            # Currently, memory growth needs to be the same across GPUs
+            for gpu in gpus:
+                tf.config.experimental.set_memory_growth(gpu, True)
+        except RuntimeError as e:
+            # Memory growth must be set before GPUs have been initialized
+            print(e)
 
     if args.checkpoint_resume:
         num_remaining_attacks = checkpoint.num_remaining_attacks

--- a/textattack/commands/train_model/run_training.py
+++ b/textattack/commands/train_model/run_training.py
@@ -1,7 +1,9 @@
+import collections
 import json
 import logging
 import math
 import os
+import random
 
 import numpy as np
 import scipy
@@ -238,26 +240,43 @@ def _data_augmentation(text, labels, augmenter):
     return flat_aug_text, flat_aug_labels
 
 
-def _generate_adversarial_examples(model, attackCls, dataset):
+def _generate_adversarial_examples(model, attack_class, dataset):
     """Create a dataset of adversarial examples based on perturbations of the
     existing dataset.
 
     :param model: Model to attack.
-    :param attackCls: class name of attack recipe to run.
+    :param attack_class: class name of attack recipe to run.
     :param dataset: iterable of (text, label) pairs.
 
-    :return: list of adversarial examples.
+    :return: list(AttackResult) of adversarial examples.
     """
-    attack = attackCls(model)
-    adv_train_text = []
+    attack = attack_class(model)
+
+    # Fix TensorFlow GPU memory growth
+    import tensorflow as tf
+
+    tf.get_logger().setLevel("WARNING")
+    gpus = tf.config.experimental.list_physical_devices("GPU")
+    if gpus:
+        try:
+            # Currently, memory growth needs to be the same across GPUs
+            for gpu in gpus:
+                tf.config.experimental.set_memory_growth(gpu, True)
+        except RuntimeError as e:
+            # Memory growth must be set before GPUs have been initialized
+            print(e)
+
+    adv_attack_results = []
     for adv_ex in tqdm.tqdm(
         attack.attack_dataset(dataset), desc="Attack", total=len(dataset)
     ):
-        adv_train_text.append(adv_ex.perturbed_text())
-    return adv_train_text
+        adv_attack_results.append(adv_ex)
+    return adv_attack_results
 
 
 def train_model(args):
+    textattack.shared.utils.set_seed(args.random_seed)
+
     logger.warn(
         "WARNING: TextAttack's model training feature is in beta. Please report any issues on our Github page, https://github.com/QData/TextAttack/issues."
     )
@@ -271,13 +290,6 @@ def train_model(args):
     fh.setLevel(logging.DEBUG)
     logger.addHandler(fh)
     logger.info(f"Writing logs to {log_txt_path}.")
-
-    # Use Weights & Biases, if enabled.
-    if args.enable_wandb:
-        global wandb
-        import wandb
-
-        wandb.init(sync_tensorboard=True)
 
     # Get list of text and list of label (integers) from disk.
     train_text, train_labels, eval_text, eval_labels = dataset_from_args(args)
@@ -309,9 +321,7 @@ def train_model(args):
     # label_id_len = len(train_labels)
     label_set = set(train_labels)
     args.num_labels = len(label_set)
-    logger.info(
-        f"Loaded dataset. Found: {args.num_labels} labels: ({sorted(label_set)})"
-    )
+    logger.info(f"Loaded dataset. Found: {args.num_labels} labels: {sorted(label_set)}")
 
     if isinstance(train_labels[0], float):
         # TODO come up with a more sophisticated scheme for knowing when to do regression
@@ -334,15 +344,14 @@ def train_model(args):
     model = model_wrapper.model
     tokenizer = model_wrapper.tokenizer
 
-    attackCls = attack_from_args(args)
+    attack_class = attack_from_args(args)
     # We are adversarial training if the user specified an attack along with
     # the training args.
-    adversarial_training = attackCls is not None
+    adversarial_training = (attack_class is not None) and (not args.check_robustness)
 
     # multi-gpu training
     if num_gpus > 1:
         model = torch.nn.DataParallel(model)
-        model.tokenizer = model.module.tokenizer
         logger.info("Using torch.nn.DataParallel.")
     logger.info(f"Training model across {num_gpus} GPUs")
 
@@ -389,9 +398,16 @@ def train_model(args):
         )
 
     # Start Tensorboard and log hyperparams.
-    from tensorboardX import SummaryWriter
+    from torch.utils.tensorboard import SummaryWriter
 
     tb_writer = SummaryWriter(args.output_dir)
+
+    # Use Weights & Biases, if enabled.
+    if args.enable_wandb:
+        global wandb
+        import wandb
+
+        wandb.init(sync_tensorboard=True)
 
     # Save original args to file
     args_save_path = os.path.join(args.output_dir, "train_args.json")
@@ -453,9 +469,11 @@ def train_model(args):
                     # only generate a new adversarial training set every args.attack_period epochs
                     # after the clean epochs
                     logger.info("Attacking model to generate new training set...")
-                    adv_train_text = _generate_adversarial_examples(
-                        model, attackCls, list(zip(train_text, train_labels))
+
+                    adv_attack_results = _generate_adversarial_examples(
+                        model_wrapper, attack_class, list(zip(train_text, train_labels))
                     )
+                    adv_train_text = [r.perturbed_text() for r in adv_attack_results]
                     train_dataloader = _make_dataloader(
                         tokenizer, adv_train_text, train_labels, args.batch_size
                     )
@@ -465,6 +483,10 @@ def train_model(args):
         prog_bar = tqdm.tqdm(
             train_dataloader, desc="Iteration", position=1, leave=False
         )
+
+        # Use these variables to track training accuracy during classification.
+        correct_predictions = 0
+        total_predictions = 0
         for step, batch in enumerate(prog_bar):
             input_ids, labels = batch
             labels = labels.to(device)
@@ -485,6 +507,10 @@ def train_model(args):
                 loss = loss_fct(logits.squeeze(), labels.squeeze())
             else:
                 loss = loss_fct(logits, labels)
+                pred_labels = logits.argmax(dim=-1)
+                correct_predictions += (pred_labels == labels).sum().item()
+                total_predictions += len(pred_labels)
+
             loss = loss_backward(loss)
             tr_loss += loss.item()
 
@@ -512,11 +538,17 @@ def train_model(args):
             # Inc step counter.
             global_step += 1
 
+        # Print training accuracy, if we're tracking it.
+        if total_predictions > 0:
+            train_acc = correct_predictions / total_predictions
+            logger.info(f"Train accuracy: {train_acc*100}%")
+            tb_writer.add_scalar("epoch_train_score", train_acc, epoch)
+
         # Check accuracy after each epoch.
         # skip args.num_clean_epochs during adversarial training
-        if not adversarial_training or epoch >= args.num_clean_epochs:
+        if (not adversarial_training) or (epoch >= args.num_clean_epochs):
             eval_score = _get_eval_score(model, eval_dataloader, args.do_regression)
-            tb_writer.add_scalar("epoch_eval_score", eval_score, global_step)
+            tb_writer.add_scalar("epoch_eval_score", eval_score, epoch)
 
             if args.checkpoint_every_epoch:
                 _save_model_checkpoint(model, args.output_dir, args.global_step)
@@ -541,6 +573,38 @@ def train_model(args):
                         f"Stopping early since it's been {args.early_stopping_epochs} steps since validation acc increased"
                     )
                     break
+
+        if args.check_robustness:
+            samples_to_attack = list(zip(train_text, train_labels))
+            samples_to_attack = random.sample(samples_to_attack, 1000)
+            adv_attack_results = _generate_adversarial_examples(
+                model_wrapper, attack_class, samples_to_attack
+            )
+            attack_types = [r.__class__.__name__ for r in adv_attack_results]
+            attack_types = collections.Counter(attack_types)
+
+            adv_acc = 1 - (
+                attack_types["SkippedAttackResult"] / len(adv_attack_results)
+            )
+            total_attacks = (
+                attack_types["SuccessfulAttackResult"]
+                + attack_types["FailedAttackResult"]
+            )
+            adv_succ_rate = attack_types["SuccessfulAttackResult"] / total_attacks
+            after_attack_acc = attack_types["FailedAttackResult"] / len(
+                adv_attack_results
+            )
+
+            tb_writer.add_scalar("robustness_test_acc", adv_acc, global_step)
+            tb_writer.add_scalar("robustness_total_attacks", total_attacks, global_step)
+            tb_writer.add_scalar(
+                "robustness_attack_succ_rate", adv_succ_rate, global_step
+            )
+            tb_writer.add_scalar(
+                "robustness_after_attack_acc", after_attack_acc, global_step
+            )
+
+            logger.info(f"Eval after-attack accuracy: {100*after_attack_acc}%")
 
     # read the saved model and report its eval performance
     logger.info("Finished training. Re-loading and evaluating model from disk.")
@@ -568,4 +632,5 @@ def train_model(args):
     write_readme(args, args.best_eval_score, args.best_eval_score_epoch)
 
     _save_args(args, args_save_path)
+    tb_writer.close()
     logger.info(f"Wrote final training args to {args_save_path}.")

--- a/textattack/commands/train_model/train_args_helpers.py
+++ b/textattack/commands/train_model/train_args_helpers.py
@@ -140,16 +140,20 @@ def model_from_args(train_args, num_labels, model_path=None):
 def attack_from_args(args):
     # note that this returns a recipe type, not an object
     # (we need to wait to have access to the model to initialize)
-    attackCls = None
+    attack_class = None
     if args.attack:
         if args.attack in ATTACK_RECIPE_NAMES:
-            attackCls = eval(ATTACK_RECIPE_NAMES[args.attack])
+            attack_class = eval(ATTACK_RECIPE_NAMES[args.attack])
         else:
             raise ValueError(f"Unrecognized attack recipe: {args.attack}")
 
     # check attack-related args
     assert args.num_clean_epochs > 0, "--num-clean-epochs must be > 0"
-    return attackCls
+    assert not (
+        args.check_robustness and not (args.attack)
+    ), "--check_robustness must be used with --attack"
+
+    return attack_class
 
 
 def augmenter_from_args(args):

--- a/textattack/commands/train_model/train_model_command.py
+++ b/textattack/commands/train_model/train_model_command.py
@@ -73,7 +73,7 @@ class TrainModelCommand(TextAttackCommand):
         parser.add_argument(
             "--tb-writer-step",
             type=int,
-            default=1000,
+            default=1,
             help="Number of steps before writing to tensorboard",
         )
         parser.add_argument(
@@ -106,6 +106,12 @@ class TrainModelCommand(TextAttackCommand):
             type=str,
             default=None,
             help="Attack recipe to use (enables adversarial training)",
+        )
+        parser.add_argument(
+            "--check-robustness",
+            default=False,
+            action="store_true",
+            help="run attack each epoch to measure robustness, but train normally",
         )
         parser.add_argument(
             "--num-clean-epochs",
@@ -196,4 +202,6 @@ class TrainModelCommand(TextAttackCommand):
             action="store_true",
             help="log metrics to Weights & Biases",
         )
+        parser.add_argument("--random-seed", default=21, type=int)
+
         parser.set_defaults(func=TrainModelCommand())

--- a/textattack/goal_functions/goal_function.py
+++ b/textattack/goal_functions/goal_function.py
@@ -14,7 +14,7 @@ class GoalFunction(ABC):
     specified goal.
 
     Args:
-        model: The model used for evaluation.
+        model_wrapper: The model used for evaluation.
         maximizable: Whether the goal function is maximizable, as opposed to a boolean result
             of success or failure.
         query_budget (float): The maximum number of model queries allowed.
@@ -24,16 +24,16 @@ class GoalFunction(ABC):
 
     def __init__(
         self,
-        model,
+        model_wrapper,
         maximizable=False,
         use_cache=True,
         query_budget=float("inf"),
         model_cache_size=2 ** 20,
     ):
         validators.validate_model_goal_function_compatibility(
-            self.__class__, model.__class__
+            self.__class__, model_wrapper.__class__
         )
-        self.model = model
+        self.model = model_wrapper
         self.maximizable = maximizable
         self.use_cache = use_cache
         self.query_budget = query_budget

--- a/textattack/shared/utils/misc.py
+++ b/textattack/shared/utils/misc.py
@@ -7,7 +7,7 @@ import torch
 
 import textattack
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 
 def html_style_from_dict(style_dict):


### PR DESCRIPTION
- attacking: fix tensorflow memory growth & gpu specification: now `--parallel` works with every recipe (including `textfooler`, `bae`, etc.)
- training: add `--check-robustness` option for running attacks each epoch and logging metrics [but not adversarial training]
- training: log to pytorch native tensorboard instead of `tensorboardX`