### PR TITLE
Replace HTML hyperlinks with Markdown image hyperlinks in ipynb docs

### DIFF
--- a/docs/datasets_models/Example_0_tensorflow.ipynb
+++ b/docs/datasets_models/Example_0_tensorflow.ipynb
@@ -14,16 +14,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table class=\"ta-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/drive/1Q7EzZ_6XDzAokTtlYSAGgdQ8NQnhC105?usp=sharing\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/QData/TextAttack/blob/master/docs/datasets_models/Example_0_tensorflow.ipynb\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing)\n",
+    "\n",
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb)"
    ]
   },
   {
@@ -437,7 +430,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/docs/datasets_models/Example_1_sklearn.ipynb
+++ b/docs/datasets_models/Example_1_sklearn.ipynb
@@ -15,16 +15,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table class=\"ta-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/drive/1cYmJfgyJdAH5Plx-7e2M_99qg1R9J6ds?usp=sharing\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/QData/TextAttack/blob/master/docs/datasets_models/Example_1_sklearn.ipynb\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing)\n",
+    "\n",
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb)"
    ]
   },
   {
@@ -298,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/docs/datasets_models/Example_2_allennlp.ipynb
+++ b/docs/datasets_models/Example_2_allennlp.ipynb
@@ -25,16 +25,9 @@
     "id": "AyPMGcz0qLfK"
    },
    "source": [
-    "<table class=\"ta-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/drive/1Inpcc6AymahreBRkOpyQJd3sqOJagtNR?usp=sharing\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/QData/TextAttack/blob/master/docs/datasets_models/Example_2_allennlp.ipynb\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing)\n",
+    "\n",
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb)"
    ]
   },
   {
@@ -321,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/docs/examples/0_End_to_End.ipynb
+++ b/docs/examples/0_End_to_End.ipynb
@@ -13,16 +13,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table class=\"ta-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/QData/TextAttack/blob/master/docs/examples/0_End_to_End.ipynb\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing)\n",
+    "\n",
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb)"
    ]
   },
   {
@@ -9948,7 +9941,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/docs/examples/1_Introduction_and_Transformations.ipynb
+++ b/docs/examples/1_Introduction_and_Transformations.ipynb
@@ -11,16 +11,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table class=\"ta-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/drive/1ce6kt-a0D_rFy_Ht4Fa7BXazLmLoKKzY?usp=sharing\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing)\n",
+    "\n",
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb)"
    ]
   },
   {
@@ -577,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,

--- a/docs/examples/2_Constraints.ipynb
+++ b/docs/examples/2_Constraints.ipynb
@@ -13,16 +13,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<table class=\"ta-notebook-buttons\" align=\"left\">\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://colab.research.google.com/drive/1kJuYTSYgEgZK7AJMwp-oIPqWCp0gg9kB?usp=sharing\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
-    "  </td>\n",
-    "  <td>\n",
-    "    <a target=\"_blank\" href=\"https://github.com/QData/TextAttack/blob/master/docs/examples/2_Constraints.ipynb\">\n",
-    "        <img src=\"https://www.tensorflow.org/images/GitHub-Mark-32px.png\" />View source on GitHub</a>\n",
-    "  </td>\n",
-    "</table>"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1cBRUj2l0m8o81vJGGFgO-o_zDLj24M5Y?usp=sharing)\n",
+    "\n",
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/examples/1_Introduction_and_Transformations.ipynb)"
    ]
   },
   {
@@ -768,7 +761,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request addresses an issue where the 'Run in Colab' buttons not rendered on readthedocs #244.

The cause of this issue is that [nbsphinx does not currently support HTML-style hyperlinks](https://github.com/spatialaudio/nbsphinx/issues/468).

This pull request changes the HTML-style hyperlinks used for the 'Run in Colab' and 'View Source in GitHub' buttons with Markdown image links. Screenshots of what that looks like are attached below.

***

The docs build correctly after running `make html`. I didn't run any of the other tests, as this change just affects the `docs/` folder.

I think I got all of the ipynb files in `docs/`. Let 

***

**Screenshot of how it looks on jupyter notebook:**

![image](https://user-images.githubusercontent.com/9489176/90326242-cdad3800-df3a-11ea-95ed-2c080c41d608.png)

**Screenshot of how it looks from the browser:**

![image](https://user-images.githubusercontent.com/9489176/90326351-3b0d9880-df3c-11ea-8041-a2135ab39444.png)