### PR TITLE
have flair use textattack tokenization method

### DIFF
--- a/tests/sample_outputs/run_attack_targetedclassification2_wordnet_langtool_log-to-csv_beamsearch2_attack_n.txt
+++ b/tests/sample_outputs/run_attack_targetedclassification2_wordnet_langtool_log-to-csv_beamsearch2_attack_n.txt
@@ -55,5 +55,5 @@
 | Attack success rate:          | 100.0% |
 | Average perturbed word %:     | 2.78%  |
 | Average num. words per input: | 28.67  |
-| Avg num queries:              | 182.0  |
+| Avg num queries:              | 181.0  |
 +-------------------------------+--------+

--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -102,7 +102,9 @@ class PartOfSpeech(Constraint):
                 )
 
             if self.tagger_type == "flair":
-                context_key_sentence = Sentence(context_key)
+                context_key_sentence = Sentence(
+                    context_key, use_tokenizer=textattack.shared.utils.words_from_text
+                )
                 self._flair_pos_tagger.predict(context_key_sentence)
                 word_list, pos_list = textattack.shared.utils.zip_flair_result(
                     context_key_sentence

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -125,7 +125,9 @@ class AttackedText:
         Uses FLAIR part-of-speech tagger.
         """
         if not self._pos_tags:
-            sentence = Sentence(self.text)
+            sentence = Sentence(
+                self.text, use_tokenizer=textattack.shared.utils.words_from_text
+            )
             textattack.shared.utils.flair_tag(sentence)
             self._pos_tags = sentence
         flair_word_list, flair_pos_list = textattack.shared.utils.zip_flair_result(

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -155,7 +155,9 @@ class AttackedText:
         Uses FLAIR ner tagger.
         """
         if not self._ner_tags:
-            sentence = Sentence(self.text)
+            sentence = Sentence(
+                self.text, use_tokenizer=textattack.shared.utils.words_from_text
+            )
             textattack.shared.utils.flair_tag(sentence, "ner")
             self._ner_tags = sentence
         flair_word_list, flair_ner_list = textattack.shared.utils.zip_flair_result(


### PR DESCRIPTION
Flair's tokenizer sometimes causes issues with POS tagging since it doesn't tokenize a sentence into words like TextAttack does. For example, if we have the word "KO'ed", Flair will tokenize it as "KO'", "ed", but TextAttack treats "KO'ed" as one word. So when we perform POS tagging, we won't find "KO'ed" in the word list returned by Flair.

Flair allows users to specify their own tokenizer as a function that takes in a string and returns a list of tokens. `textattack.shared.utils.words_from_text` does this exactly.