### PR TITLE
New augmenter

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -16,3 +16,29 @@ def test_embedding_augmenter():
         "There is nothing either good or unfavourable, but thinking makes it so."
     )
     assert augmented_s in augmented_text_list
+
+
+def test_checklist_augmenter():
+    from textattack.augmentation import CheckListAugmenter
+
+    augmenter = CheckListAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    s = "I'll be happy to assist you."
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "I will be happy to assist you."
+    assert augmented_s in augmented_text_list
+
+    s = "I will be happy to assist you."
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "I'll be happy to assist you."
+    assert augmented_s in augmented_text_list
+
+
+def test_charwap_augmenter():
+    from textattack.augmentation import CharSwapAugmenter
+
+    augmenter = CharSwapAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    s = "To be or not to be"
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "T be or not to be"
+    assert augmented_s in augmented_text_list
+

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -47,12 +47,6 @@ def test_easydata_augmenter():
     from textattack.augmentation import EasyDataAugmenter
 
     augmenter = EasyDataAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
-    s = "I love sushi"
-    augmented_text_list = augmenter.augment(s)
-    augmented_s = "sushi I love"
-    assert augmented_s in augmented_text_list
-
-    augmenter = EasyDataAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
     s = "Hakuna Montana"
     augmented_text_list = augmenter.augment(s)
     augmented_s = "Montana Hakuna"
@@ -63,7 +57,7 @@ def test_wordnet_augmenter():
     from textattack.augmentation import WordNetAugmenter
 
     augmenter = WordNetAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
-    s = "The Dragon warrior is a panda "
+    s = "The Dragon warrior is a panda"
     augmented_text_list = augmenter.augment(s)
     augmented_s = "The firedrake warrior is a panda"
     assert augmented_s in augmented_text_list

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,7 +9,7 @@ def test_imports():
 def test_embedding_augmenter():
     from textattack.augmentation import EmbeddingAugmenter
 
-    augmenter = EmbeddingAugmenter(transformations_per_example=64)
+    augmenter = EmbeddingAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
     s = "There is nothing either good or bad, but thinking makes it so."
     augmented_text_list = augmenter.augment(s)
     augmented_s = (
@@ -42,3 +42,28 @@ def test_charwap_augmenter():
     augmented_s = "T be or not to be"
     assert augmented_s in augmented_text_list
 
+
+def test_easydata_augmenter():
+    from textattack.augmentation import EasyDataAugmenter
+
+    augmenter = EasyDataAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    s = "I love sushi"
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "sushi I love"
+    assert augmented_s in augmented_text_list
+
+    augmenter = EasyDataAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    s = "Hakuna Montana"
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "Montana Hakuna"
+    assert augmented_s in augmented_text_list
+
+
+def test_wordnet_augmenter():
+    from textattack.augmentation import WordNetAugmenter
+
+    augmenter = WordNetAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    s = "The Dragon warrior is a panda "
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "The firedrake warrior is a panda"
+    assert augmented_s in augmented_text_list

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -9,7 +9,9 @@ def test_imports():
 def test_embedding_augmenter():
     from textattack.augmentation import EmbeddingAugmenter
 
-    augmenter = EmbeddingAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    augmenter = EmbeddingAugmenter(
+        pct_words_to_swap=0.01, transformations_per_example=64
+    )
     s = "There is nothing either good or bad, but thinking makes it so."
     augmented_text_list = augmenter.augment(s)
     augmented_s = (
@@ -21,7 +23,9 @@ def test_embedding_augmenter():
 def test_checklist_augmenter():
     from textattack.augmentation import CheckListAugmenter
 
-    augmenter = CheckListAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    augmenter = CheckListAugmenter(
+        pct_words_to_swap=0.01, transformations_per_example=64
+    )
     s = "I'll be happy to assist you."
     augmented_text_list = augmenter.augment(s)
     augmented_s = "I will be happy to assist you."
@@ -36,7 +40,9 @@ def test_checklist_augmenter():
 def test_charwap_augmenter():
     from textattack.augmentation import CharSwapAugmenter
 
-    augmenter = CharSwapAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    augmenter = CharSwapAugmenter(
+        pct_words_to_swap=0.01, transformations_per_example=64
+    )
     s = "To be or not to be"
     augmented_text_list = augmenter.augment(s)
     augmented_s = "T be or not to be"
@@ -46,7 +52,9 @@ def test_charwap_augmenter():
 def test_easydata_augmenter():
     from textattack.augmentation import EasyDataAugmenter
 
-    augmenter = EasyDataAugmenter(pct_words_to_swap=0.01, transformations_per_example=64)
+    augmenter = EasyDataAugmenter(
+        pct_words_to_swap=0.01, transformations_per_example=64
+    )
     s = "Hakuna Montana"
     augmented_text_list = augmenter.augment(s)
     augmented_s = "Montana Hakuna"

--- a/textattack/augmentation/__init__.py
+++ b/textattack/augmentation/__init__.py
@@ -5,4 +5,5 @@ from .recipes import (
     CharSwapAugmenter,
     EasyDataAugmenter,
     CheckListAugmenter,
+    DeletionAugmenter,
 )

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -100,7 +100,6 @@ class Augmenter:
                 # update words_swapped based on modified indices
                 words_swapped = len(current_text.attack_attrs["modified_indices"])
             all_transformed_texts.add(current_text)
-            print(all_transformed_texts)
         return sorted([at.printable_text() for at in all_transformed_texts])
 
     def augment_many(self, text_list, show_progress=False):

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -80,11 +80,12 @@ class Augmenter:
                 transformed_texts = self.transformation(
                     current_text, self.pre_transformation_constraints
                 )
+                # print(1, transformed_texts)
                 # Get rid of transformations we already have
                 transformed_texts = [
                     t for t in transformed_texts if t not in all_transformed_texts
                 ]
-
+                # print(2, transformed_texts)
                 # Filter out transformations that don't match the constraints.
                 transformed_texts = self._filter_transformations(
                     transformed_texts, current_text, original_text
@@ -92,13 +93,17 @@ class Augmenter:
 
                 # if there's no more transformed texts after filter, terminate
                 if not len(transformed_texts):
+                    # print("break!!!")
                     break
 
                 current_text = random.choice(transformed_texts)
+                # print(3, current_text)
 
+                # update words_swapped based on modified indices
                 words_swapped = len(current_text.attack_attrs["modified_indices"])
 
             all_transformed_texts.add(current_text)
+            # print(all_transformed_texts)
         return sorted([at.printable_text() for at in all_transformed_texts])
 
     def augment_many(self, text_list, show_progress=False):

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -73,28 +73,31 @@ class Augmenter:
             int(self.pct_words_to_swap * len(attacked_text.words)), 1
         )
         for _ in range(self.transformations_per_example):
-            index_order = list(range(len(attacked_text.words)))
-            random.shuffle(index_order)
             current_text = attacked_text
-            words_swapped = 0
-            for i in index_order:
+            words_swapped = len(current_text.attack_attrs["modified_indices"])
+
+            while words_swapped <= num_words_to_swap:
                 transformed_texts = self.transformation(
-                    current_text, self.pre_transformation_constraints, [i]
+                    current_text, self.pre_transformation_constraints
                 )
                 # Get rid of transformations we already have
                 transformed_texts = [
                     t for t in transformed_texts if t not in all_transformed_texts
                 ]
+
                 # Filter out transformations that don't match the constraints.
                 transformed_texts = self._filter_transformations(
                     transformed_texts, current_text, original_text
                 )
+
+                # if there's no more transformed texts after filter, terminate
                 if not len(transformed_texts):
-                    continue
-                current_text = random.choice(transformed_texts)
-                words_swapped += 1
-                if words_swapped == num_words_to_swap:
                     break
+
+                current_text = random.choice(transformed_texts)
+
+                words_swapped = len(current_text.attack_attrs["modified_indices"])
+
             all_transformed_texts.add(current_text)
         return sorted([at.printable_text() for at in all_transformed_texts])
 

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -100,6 +100,7 @@ class Augmenter:
                 # update words_swapped based on modified indices
                 words_swapped = len(current_text.attack_attrs["modified_indices"])
             all_transformed_texts.add(current_text)
+            print(all_transformed_texts)
         return sorted([at.printable_text() for at in all_transformed_texts])
 
     def augment_many(self, text_list, show_progress=False):

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -76,16 +76,16 @@ class Augmenter:
             current_text = attacked_text
             words_swapped = len(current_text.attack_attrs["modified_indices"])
 
-            while words_swapped <= num_words_to_swap:
+            while words_swapped < num_words_to_swap:
                 transformed_texts = self.transformation(
                     current_text, self.pre_transformation_constraints
                 )
-                # print(1, transformed_texts)
+
                 # Get rid of transformations we already have
                 transformed_texts = [
                     t for t in transformed_texts if t not in all_transformed_texts
                 ]
-                # print(2, transformed_texts)
+
                 # Filter out transformations that don't match the constraints.
                 transformed_texts = self._filter_transformations(
                     transformed_texts, current_text, original_text
@@ -93,17 +93,13 @@ class Augmenter:
 
                 # if there's no more transformed texts after filter, terminate
                 if not len(transformed_texts):
-                    # print("break!!!")
                     break
 
                 current_text = random.choice(transformed_texts)
-                # print(3, current_text)
 
                 # update words_swapped based on modified indices
                 words_swapped = len(current_text.attack_attrs["modified_indices"])
-
             all_transformed_texts.add(current_text)
-            # print(all_transformed_texts)
         return sorted([at.printable_text() for at in all_transformed_texts])
 
     def augment_many(self, text_list, show_progress=False):

--- a/textattack/commands/augment.py
+++ b/textattack/commands/augment.py
@@ -48,10 +48,15 @@ class AugmentCommand(TextAttackCommand):
                     break
 
                 elif text == "c":
-                    print(f"\nCurrent arguments: {args.recipe}, pct_words_to_swap: {args.pct_words_to_swap}, "
-                          f"transformations_per_example: {args.transformations_per_example}")
+                    print(
+                        f"\nCurrent Arguments:\n\n\t augmentation recipe: {args.recipe}, "
+                        f"\n\t pct_words_to_swap: {args.pct_words_to_swap}, "
+                        f"\n\t transformations_per_example: {args.transformations_per_example}\n"
+                    )
 
-                    change = input("Enter 'c' again to change arguments, any other keys to opt out\n")
+                    change = input(
+                        "Enter 'c' again to change arguments, any other keys to opt out\n"
+                    )
                     if change == "c":
                         print("\nChanging augmenter arguments...\n")
                         recipe = input(
@@ -75,10 +80,11 @@ class AugmentCommand(TextAttackCommand):
                             pct_words_to_swap=args.pct_words_to_swap,
                             transformations_per_example=args.transformations_per_example,
                         )
-                        print("--------------------------------------------------------")
+                        print(
+                            "--------------------------------------------------------"
+                        )
 
                     continue
-
 
                 elif not text:
                     continue

--- a/textattack/commands/augment.py
+++ b/textattack/commands/augment.py
@@ -40,7 +40,7 @@ class AugmentCommand(TextAttackCommand):
 
             while True:
                 print(
-                    '\nEnter a sentence to augment, "q" to quit, "c" to change arguments:\n'
+                    '\nEnter a sentence to augment, "q" to quit, "c" to view/change arguments:\n'
                 )
                 text = input()
 
@@ -48,30 +48,37 @@ class AugmentCommand(TextAttackCommand):
                     break
 
                 elif text == "c":
-                    print("\nChanging augmenter arguments...\n")
-                    recipe = input(
-                        "\tAugmentation recipe name ('r' to see available recipes):  "
-                    )
-                    if recipe == "r":
-                        print("\n\twordnet, embedding, charswap, eda\n")
-                        args.recipe = input("\tAugmentation recipe name:  ")
-                    else:
-                        args.recipe = recipe
+                    print(f"\nCurrent arguments: {args.recipe}, pct_words_to_swap: {args.pct_words_to_swap}, "
+                          f"transformations_per_example: {args.transformations_per_example}")
 
-                    args.pct_words_to_swap = float(
-                        input("\tPercentage of words to swap (0.0 ~ 1.0):  ")
-                    )
-                    args.transformations_per_example = int(
-                        input("\tTransformations per input example:  ")
-                    )
+                    change = input("Enter 'c' again to change arguments, any other keys to opt out\n")
+                    if change == "c":
+                        print("\nChanging augmenter arguments...\n")
+                        recipe = input(
+                            "\tAugmentation recipe name ('r' to see available recipes):  "
+                        )
+                        if recipe == "r":
+                            print("\n\twordnet, embedding, charswap, eda, checklist\n")
+                            args.recipe = input("\tAugmentation recipe name:  ")
+                        else:
+                            args.recipe = recipe
 
-                    print("\nGenerating new augmenter...\n")
-                    augmenter = eval(AUGMENTATION_RECIPE_NAMES[args.recipe])(
-                        pct_words_to_swap=args.pct_words_to_swap,
-                        transformations_per_example=args.transformations_per_example,
-                    )
-                    print("--------------------------------------------------------")
+                        args.pct_words_to_swap = float(
+                            input("\tPercentage of words to swap (0.0 ~ 1.0):  ")
+                        )
+                        args.transformations_per_example = int(
+                            input("\tTransformations per input example:  ")
+                        )
+
+                        print("\nGenerating new augmenter...\n")
+                        augmenter = eval(AUGMENTATION_RECIPE_NAMES[args.recipe])(
+                            pct_words_to_swap=args.pct_words_to_swap,
+                            transformations_per_example=args.transformations_per_example,
+                        )
+                        print("--------------------------------------------------------")
+
                     continue
+
 
                 elif not text:
                     continue

--- a/textattack/commands/augment.py
+++ b/textattack/commands/augment.py
@@ -14,6 +14,7 @@ AUGMENTATION_RECIPE_NAMES = {
     "charswap": "textattack.augmentation.CharSwapAugmenter",
     "eda": "textattack.augmentation.EasyDataAugmenter",
     "checklist": "textattack.augmentation.CheckListAugmenter",
+    "deletion": "textattack.augmentation.DeletionAugmenter"
 }
 
 
@@ -63,7 +64,7 @@ class AugmentCommand(TextAttackCommand):
                             "\tAugmentation recipe name ('r' to see available recipes):  "
                         )
                         if recipe == "r":
-                            print("\n\twordnet, embedding, charswap, eda, checklist\n")
+                            print("\n\twordnet, embedding, charswap, eda, checklist, deletion\n")
                             args.recipe = input("\tAugmentation recipe name:  ")
                         else:
                             args.recipe = recipe

--- a/textattack/commands/augment.py
+++ b/textattack/commands/augment.py
@@ -14,7 +14,6 @@ AUGMENTATION_RECIPE_NAMES = {
     "charswap": "textattack.augmentation.CharSwapAugmenter",
     "eda": "textattack.augmentation.EasyDataAugmenter",
     "checklist": "textattack.augmentation.CheckListAugmenter",
-    "deletion": "textattack.augmentation.DeletionAugmenter"
 }
 
 
@@ -64,7 +63,7 @@ class AugmentCommand(TextAttackCommand):
                             "\tAugmentation recipe name ('r' to see available recipes):  "
                         )
                         if recipe == "r":
-                            print("\n\twordnet, embedding, charswap, eda, checklist, deletion\n")
+                            print("\n\twordnet, embedding, charswap, eda, checklist\n")
                             args.recipe = input("\tAugmentation recipe name:  ")
                         else:
                             args.recipe = recipe


### PR DESCRIPTION
The augmenter we have right now only supports single word swaps, making many transformations inapplicable for augmentation purposes. 

The complicity here is due to the parameter `pct_words_to_swap `, which allows users to set the maximum number of words to swap during augmentation. We have to call transformation as many times as we can, but the max number of words swapped can not exceed the allowance set by user. What I changed here is to use the length of `AttackedText.attack_attrs["modified_indices"]` to count the number of swapped words, instead of the previous method of using a list of random indices to perform single word swap. In this way, we could perform any transformation, see if it fits the constraints/allowance, then decide to whether return the augmentation or continue swapping.

An option to display current Augmenter parameter is added to interactively running the augmenter.

I also noticed that we have only augmentation test! I'll add more if it won't slow down the current test too much.

