### PR TITLE
add lazy_load to load Stanza

### DIFF
--- a/examples/attack/attack_camembert.py
+++ b/examples/attack/attack_camembert.py
@@ -1,12 +1,12 @@
+# Quiet TensorFlow.
+import os
+
+import numpy as np
+from transformers import AutoTokenizer, TFAutoModelForSequenceClassification, pipeline
+
 from textattack.attack_recipes import PWWSRen2019
 from textattack.datasets import HuggingFaceDataset
 from textattack.models.wrappers import ModelWrapper
-from transformers import AutoTokenizer, TFAutoModelForSequenceClassification, pipeline
-
-import numpy as np
-
-# Quiet TensorFlow.
-import os
 
 if "TF_CPP_MIN_LOG_LEVEL" not in os.environ:
     os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ wandb
 word2number
 num2words
 more-itertools
+importlib

--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -8,7 +8,6 @@ from flair.models import SequenceTagger
 import lru
 import nltk
 
-
 import textattack
 from textattack.constraints import Constraint
 from textattack.shared.validators import transformation_consists_of_word_swaps
@@ -17,10 +16,10 @@ from textattack.shared.validators import transformation_consists_of_word_swaps
 flair.device = textattack.shared.utils.device
 
 
+import importlib.util
 # a work around to get stanza lazy load
 # import stanza
 import sys
-import importlib.util
 
 
 def lazy_load(fullname):

--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -7,7 +7,7 @@ from flair.data import Sentence
 from flair.models import SequenceTagger
 import lru
 import nltk
-import stanza
+
 
 import textattack
 from textattack.constraints import Constraint
@@ -15,6 +15,27 @@ from textattack.shared.validators import transformation_consists_of_word_swaps
 
 # Set global flair device to be TextAttack's current device
 flair.device = textattack.shared.utils.device
+
+
+# a work around to get stanza lazy load
+# import stanza
+import sys
+import importlib.util
+
+
+def lazy_load(fullname):
+    try:
+        return sys.modules[fullname]
+    except KeyError:
+        spec = importlib.util.find_spec(fullname)
+        module = importlib.util.module_from_spec(spec)
+        loader = importlib.util.LazyLoader(spec.loader)
+        # Make module with proper locking and get it inserted into sys.modules.
+        loader.exec_module(module)
+        return module
+
+
+stanza = lazy_load("stanza")
 
 
 def load_flair_upos_fast():

--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -2,6 +2,9 @@
 Part of Speech Constraint
 --------------------------
 """
+import importlib.util
+import sys
+
 import flair
 from flair.data import Sentence
 from flair.models import SequenceTagger
@@ -16,12 +19,8 @@ from textattack.shared.validators import transformation_consists_of_word_swaps
 flair.device = textattack.shared.utils.device
 
 
-import importlib.util
 # a work around to get stanza lazy load
 # import stanza
-import sys
-
-
 def lazy_load(fullname):
     try:
         return sys.modules[fullname]


### PR DESCRIPTION
Due to the long loading time of the "import stanza", our readthedocs built failed due to long time/memory cost. So here is the lazy_load try to import stanza lazily. 

I have to merge this type of pull request more frequently because we set the readthedocs to build our documentation from the master branch. 
I don't know  other ways to know if a version I revised works well or not in readthedocs 
(my merged versions were all after extensive local built and tests)