### PR TITLE
Lazy loading

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -35,4 +35,4 @@ jobs:
         pip install jupyter 'ipykernel<5.0.0' 'ipython<7.0.0' # ipykernel workaround: github.com/jupyter/notebook/issues/4050
     - name: Build docs with Sphinx and check for errors
       run: |
-        sphinx-build -b html docs docs/_build/html -W
+        TEXTATTACK_DOC_BUILD=TRUE sphinx-build -b html docs docs/_build/html -W

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ test: FORCE ## Run tests using pytest
 	python -m pytest --dist=loadfile -n auto
 
 docs: FORCE ## Build docs using Sphinx.
-	sphinx-build -b html docs docs/_build/html 
+	TEXTATTACK_DOC_BUILD=TRUE sphinx-build -b html docs docs/_build/html 
 
 docs-check: FORCE ## Builds docs using Sphinx. If there is an error, exit with an error code (instead of warning & continuing).
-	sphinx-build -b html docs docs/_build/html -W
+	TEXTATTACK_DOC_BUILD=TRUE sphinx-build -b html docs docs/_build/html -W
 
 docs-auto: FORCE ## Build docs using Sphinx and run hotreload server using Sphinx autobuild.
-	sphinx-autobuild docs docs/_build/html -H 0.0.0.0 -p 8765
+	TEXTATTACK_DOC_BUILD=TRUE sphinx-autobuild docs docs/_build/html -H 0.0.0.0 -p 8765
 
 all: format lint docs-check test ## Format, lint, and test. 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ datasets
 nltk
 numpy<1.19.0 #TF 2.0 requires this
 pandas>=1.0.1
-scikit-learn
 scipy==1.4.1
 sentence_transformers>0.2.6
 stanza

--- a/textattack/__init__.py
+++ b/textattack/__init__.py
@@ -1,5 +1,4 @@
-"""
-Welcome to the API references for TextAttack!
+"""Welcome to the API references for TextAttack!
 
 What is TextAttack?
 

--- a/textattack/attack_recipes/__init__.py
+++ b/textattack/attack_recipes/__init__.py
@@ -1,5 +1,4 @@
-"""
-.. _attack_recipes:
+""".. _attack_recipes:
 
 Attack Recipes:
 ======================
@@ -17,7 +16,6 @@ For example, ``attack = InputReductionFeng2018.build(model)`` creates `attack`, 
 TextAttack supports the following attack recipes (each recipe's documentation contains a link to the corresponding paper):
 
 .. contents:: :local:
-
 """
 
 from .attack_recipe import AttackRecipe

--- a/textattack/attack_recipes/pruthi_2019.py
+++ b/textattack/attack_recipes/pruthi_2019.py
@@ -24,7 +24,8 @@ from .attack_recipe import AttackRecipe
 
 
 class Pruthi2019(AttackRecipe):
-    """An implementation of the attack used in "Combating Adversarial Misspellings with Robust Word Recognition", Pruthi et al., 2019.
+    """An implementation of the attack used in "Combating Adversarial
+    Misspellings with Robust Word Recognition", Pruthi et al., 2019.
 
     This attack focuses on a small number of character-level changes that simulate common typos. It combines:
         - Swapping neighboring characters

--- a/textattack/augmentation/__init__.py
+++ b/textattack/augmentation/__init__.py
@@ -1,12 +1,9 @@
-"""
-
-.. _augmentation:
+""".. _augmentation:
 
 Augmenter:
 ==================
 
 Transformations and constraints can be used outside of an attack for simple NLP data augmentation with the ``Augmenter`` class that returns all possible transformations for a given string.
-
 """
 from .augmenter import Augmenter
 from .recipes import (

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -7,14 +7,11 @@ Transformations and constraints can be used for simple NLP data augmentations. H
 """
 import random
 
-import textattack
+from textattack.constraints.pre_transformation import RepeatModification, StopwordModification
 
 from . import Augmenter
 
-DEFAULT_CONSTRAINTS = [
-    textattack.constraints.pre_transformation.RepeatModification(),
-    textattack.constraints.pre_transformation.StopwordModification(),
-]
+DEFAULT_CONSTRAINTS = [RepeatModification(), StopwordModification()]
 
 
 class EasyDataAugmenter(Augmenter):

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -7,7 +7,10 @@ Transformations and constraints can be used for simple NLP data augmentations. H
 """
 import random
 
-from textattack.constraints.pre_transformation import RepeatModification, StopwordModification
+from textattack.constraints.pre_transformation import (
+    RepeatModification,
+    StopwordModification,
+)
 
 from . import Augmenter
 

--- a/textattack/commands/attack/run_attack_parallel.py
+++ b/textattack/commands/attack/run_attack_parallel.py
@@ -42,17 +42,20 @@ def set_env_variables(gpu_id):
     torch.cuda.set_device(gpu_id)
 
     # Fix TensorFlow GPU memory growth
-    import tensorflow as tf
+    try:
+        import tensorflow as tf
 
-    gpus = tf.config.experimental.list_physical_devices("GPU")
-    if gpus:
-        try:
-            # Currently, memory growth needs to be the same across GPUs
-            gpu = gpus[gpu_id]
-            tf.config.experimental.set_visible_devices(gpu, "GPU")
-            tf.config.experimental.set_memory_growth(gpu, True)
-        except RuntimeError as e:
-            print(e)
+        gpus = tf.config.experimental.list_physical_devices("GPU")
+        if gpus:
+            try:
+                # Currently, memory growth needs to be the same across GPUs
+                gpu = gpus[gpu_id]
+                tf.config.experimental.set_visible_devices(gpu, "GPU")
+                tf.config.experimental.set_memory_growth(gpu, True)
+            except RuntimeError as e:
+                print(e)
+    except ModuleNotFoundError:
+        pass
 
 
 def attack_from_queue(args, in_queue, out_queue):

--- a/textattack/commands/attack/run_attack_single_threaded.py
+++ b/textattack/commands/attack/run_attack_single_threaded.py
@@ -32,18 +32,22 @@ def run(args, checkpoint=None):
     # Disable tensorflow logs, except in the case of an error.
     if "TF_CPP_MIN_LOG_LEVEL" not in os.environ:
         os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
-    # Fix TensorFlow GPU memory growth
-    import tensorflow as tf
 
-    gpus = tf.config.experimental.list_physical_devices("GPU")
-    if gpus:
-        try:
-            # Currently, memory growth needs to be the same across GPUs
-            for gpu in gpus:
-                tf.config.experimental.set_memory_growth(gpu, True)
-        except RuntimeError as e:
-            # Memory growth must be set before GPUs have been initialized
-            print(e)
+    try:
+        # Fix TensorFlow GPU memory growth
+        import tensorflow as tf
+
+        gpus = tf.config.experimental.list_physical_devices("GPU")
+        if gpus:
+            try:
+                # Currently, memory growth needs to be the same across GPUs
+                for gpu in gpus:
+                    tf.config.experimental.set_memory_growth(gpu, True)
+            except RuntimeError as e:
+                # Memory growth must be set before GPUs have been initialized
+                print(e)
+    except ModuleNotFoundError:
+        pass
 
     if args.checkpoint_resume:
         num_remaining_attacks = checkpoint.num_remaining_attacks

--- a/textattack/commands/train_model/run_training.py
+++ b/textattack/commands/train_model/run_training.py
@@ -252,19 +252,22 @@ def _generate_adversarial_examples(model, attack_class, dataset):
     """
     attack = attack_class(model)
 
-    # Fix TensorFlow GPU memory growth
-    import tensorflow as tf
+    try:
+        # Fix TensorFlow GPU memory growth
+        import tensorflow as tf
 
-    tf.get_logger().setLevel("WARNING")
-    gpus = tf.config.experimental.list_physical_devices("GPU")
-    if gpus:
-        try:
-            # Currently, memory growth needs to be the same across GPUs
-            for gpu in gpus:
-                tf.config.experimental.set_memory_growth(gpu, True)
-        except RuntimeError as e:
-            # Memory growth must be set before GPUs have been initialized
-            print(e)
+        tf.get_logger().setLevel("WARNING")
+        gpus = tf.config.experimental.list_physical_devices("GPU")
+        if gpus:
+            try:
+                # Currently, memory growth needs to be the same across GPUs
+                for gpu in gpus:
+                    tf.config.experimental.set_memory_growth(gpu, True)
+            except RuntimeError as e:
+                # Memory growth must be set before GPUs have been initialized
+                print(e)
+    except ModuleNotFoundError:
+        pass
 
     adv_attack_results = []
     for adv_ex in tqdm.tqdm(

--- a/textattack/constraints/__init__.py
+++ b/textattack/constraints/__init__.py
@@ -1,5 +1,4 @@
-"""
-.. _constraint:
+""".. _constraint:
 
 Constraint Package
 ===================
@@ -17,7 +16,6 @@ We split constraints into three main categories.
 A fourth type of constraint restricts the search method from exploring certain parts of the search space:
 
    :ref:`pre_transformation <pre_transformation>`: Based on the input and index of word replacement.
-
 """
 
 from .pre_transformation_constraint import PreTransformationConstraint

--- a/textattack/constraints/grammaticality/__init__.py
+++ b/textattack/constraints/grammaticality/__init__.py
@@ -1,13 +1,10 @@
-"""
-
-.. _grammaticality:
+""".. _grammaticality:
 
 Grammaticality:
 --------------------------
 
 Grammaticality constraints determine if a transformation is valid based on
 syntactic properties of the perturbation.
-
 """
 
 from . import language_models

--- a/textattack/constraints/grammaticality/language_models/google_language_model/alzantot_goog_lm.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/alzantot_goog_lm.py
@@ -12,11 +12,12 @@ import os
 
 import lru
 import numpy as np
-import tensorflow as tf
 
 from textattack.shared import utils
 
 from . import lm_data_utils, lm_utils
+
+tf = utils.LazyLoader("tensorflow", globals(), "tensorflow")
 
 tf.get_logger().setLevel("INFO")
 

--- a/textattack/constraints/grammaticality/language_models/google_language_model/lm_data_utils.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/lm_data_utils.py
@@ -25,9 +25,9 @@ import random
 
 import numpy as np
 
-import textattack
+from textattack.shared.utils import LazyLoader
 
-tf = textattack.shared.utils.LazyLoader("tensorflow", globals(), "tensorflow")
+tf = LazyLoader("tensorflow", globals(), "tensorflow")
 
 
 class Vocabulary(object):

--- a/textattack/constraints/grammaticality/language_models/google_language_model/lm_data_utils.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/lm_data_utils.py
@@ -24,7 +24,10 @@ A library for loading 1B word benchmark dataset.
 import random
 
 import numpy as np
-import tensorflow as tf
+
+import textattack
+
+tf = textattack.shared.utils.LazyLoader("tensorflow", globals(), "tensorflow")
 
 
 class Vocabulary(object):

--- a/textattack/constraints/grammaticality/language_models/google_language_model/lm_utils.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/lm_utils.py
@@ -7,8 +7,11 @@ Utils for loading 1B word benchmark dataset.
 """
 import sys
 
-from google.protobuf import text_format
-import tensorflow as tf
+import textattack
+
+tf = textattack.shared.utils.LazyLoader("tensorflow", globals(), "tensorflow")
+
+from google.protobuf import text_format  # noqa: E402
 
 tf.get_logger().setLevel("INFO")
 

--- a/textattack/constraints/grammaticality/language_models/google_language_model/lm_utils.py
+++ b/textattack/constraints/grammaticality/language_models/google_language_model/lm_utils.py
@@ -7,9 +7,9 @@ Utils for loading 1B word benchmark dataset.
 """
 import sys
 
-import textattack
+from textattack.shared.utils import LazyLoader
 
-tf = textattack.shared.utils.LazyLoader("tensorflow", globals(), "tensorflow")
+tf = LazyLoader("tensorflow", globals(), "tensorflow")
 
 from google.protobuf import text_format  # noqa: E402
 

--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -7,7 +7,6 @@ from flair.data import Sentence
 from flair.models import SequenceTagger
 import lru
 import nltk
-import stanza
 
 import textattack
 from textattack.constraints import Constraint
@@ -15,6 +14,8 @@ from textattack.shared.validators import transformation_consists_of_word_swaps
 
 # Set global flair device to be TextAttack's current device
 flair.device = textattack.shared.utils.device
+
+stanza = textattack.shared.utils.LazyLoader("stanza", globals(), "stanza")
 
 
 def load_flair_upos_fast():

--- a/textattack/constraints/overlap/__init__.py
+++ b/textattack/constraints/overlap/__init__.py
@@ -1,12 +1,9 @@
-"""
-
-.. _overlap:
+""".. _overlap:
 
 Overlap Constraints
 --------------------------
 
 Overlap constraints determine if a transformation is valid based on character-level analysis.
-
 """
 
 from .bleu_score import BLEU

--- a/textattack/constraints/pre_transformation/__init__.py
+++ b/textattack/constraints/pre_transformation/__init__.py
@@ -1,13 +1,9 @@
-"""
-
-.. _pre_transformation:
-
+""".. _pre_transformation:
 
 Pre-Transformation:
 ---------------------
 
 Pre-transformation constraints determine if a transformation is valid based on only the original input and the position of the replacement. These constraints are applied before the transformation is even called. For example, these constraints can prevent search methods from swapping words at the same index twice, or from replacing stopwords.
-
 """
 from .stopword_modification import StopwordModification
 from .repeat_modification import RepeatModification

--- a/textattack/constraints/semantics/__init__.py
+++ b/textattack/constraints/semantics/__init__.py
@@ -1,11 +1,8 @@
-"""
-
-.. _semantics:
+""".. _semantics:
 
 Semantic Constraints
 ---------------------
 Semantic constraints determine if a transformation is valid based on similarity of the semantics of the orignal input and the transformed input.
-
 """
 from . import sentence_encoders
 

--- a/textattack/constraints/semantics/bert_score.py
+++ b/textattack/constraints/semantics/bert_score.py
@@ -18,8 +18,7 @@ from textattack.shared import utils
 
 
 class BERTScore(Constraint):
-    """
-    A constraint on BERT-Score difference.
+    """A constraint on BERT-Score difference.
 
     Args:
         min_bert_score (float), minimum threshold value for BERT-Score
@@ -33,7 +32,6 @@ class BERTScore(Constraint):
         compare_against_original (bool):
             If ``True``, compare new ``x_adv`` against the original ``x``.
             Otherwise, compare it against the previous ``x_adv``.
-
     """
 
     SCORE_TYPE2IDX = {"precision": 0, "recall": 1, "f1": 2}
@@ -60,7 +58,8 @@ class BERTScore(Constraint):
         )
 
     def _check_constraint(self, transformed_text, reference_text):
-        """Return `True` if BERT Score between `transformed_text` and `reference_text` is lower than minimum BERT Score."""
+        """Return `True` if BERT Score between `transformed_text` and
+        `reference_text` is lower than minimum BERT Score."""
         cand = transformed_text.text
         ref = reference_text.text
         result = self._bert_scorer.score([cand], [ref])

--- a/textattack/constraints/semantics/sentence_encoders/bert/bert.py
+++ b/textattack/constraints/semantics/sentence_encoders/bert/bert.py
@@ -3,10 +3,12 @@ BERT for Sentence Similarity
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 """
 
-from sentence_transformers import SentenceTransformer
-
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder
 from textattack.shared import utils
+
+sentence_transformers = utils.LazyLoader(
+    "sentence_transformers", globals(), "sentence_transformers"
+)
 
 
 class BERT(SentenceEncoder):
@@ -16,7 +18,9 @@ class BERT(SentenceEncoder):
 
     def __init__(self, threshold=0.7, metric="cosine", **kwargs):
         super().__init__(threshold=threshold, metric=metric, **kwargs)
-        self.model = SentenceTransformer("bert-base-nli-stsb-mean-tokens")
+        self.model = sentence_transformers.SentenceTransformer(
+            "bert-base-nli-stsb-mean-tokens"
+        )
         self.model.to(utils.device)
 
     def encode(self, sentences):

--- a/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/multilingual_universal_sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/multilingual_universal_sentence_encoder.py
@@ -3,10 +3,13 @@ multilingual universal sentence encoder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 """
 
-import tensorflow_hub as hub
-import tensorflow_text  # noqa: F401
-
+import textattack
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder
+
+hub = textattack.shared.utils.LazyLoader("tensorflow_hub", globals(), "tensorflow_hub")
+tensorflow_text = textattack.shared.utils.LazyLoader(
+    "tensorflow_text", globals(), "tensorflow_text"
+)  # noqa: F401
 
 
 class MultilingualUniversalSentenceEncoder(SentenceEncoder):

--- a/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/multilingual_universal_sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/multilingual_universal_sentence_encoder.py
@@ -3,11 +3,11 @@ multilingual universal sentence encoder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 """
 
-import textattack
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder
+from textattack.shared.utils import LazyLoader
 
-hub = textattack.shared.utils.LazyLoader("tensorflow_hub", globals(), "tensorflow_hub")
-tensorflow_text = textattack.shared.utils.LazyLoader(
+hub = LazyLoader("tensorflow_hub", globals(), "tensorflow_hub")
+tensorflow_text = LazyLoader(
     "tensorflow_text", globals(), "tensorflow_text"
 )  # noqa: F401
 

--- a/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/universal_sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/universal_sentence_encoder.py
@@ -3,10 +3,10 @@ universal sentence encoder class
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 """
 
-import textattack
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder
+from textattack.shared.utils import LazyLoader
 
-hub = textattack.shared.utils.LazyLoader("tensorflow_hub", globals(), "tensorflow_hub")
+hub = LazyLoader("tensorflow_hub", globals(), "tensorflow_hub")
 
 
 class UniversalSentenceEncoder(SentenceEncoder):

--- a/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/universal_sentence_encoder.py
+++ b/textattack/constraints/semantics/sentence_encoders/universal_sentence_encoder/universal_sentence_encoder.py
@@ -3,10 +3,10 @@ universal sentence encoder class
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 """
 
-
-import tensorflow_hub as hub
-
+import textattack
 from textattack.constraints.semantics.sentence_encoders import SentenceEncoder
+
+hub = textattack.shared.utils.LazyLoader("tensorflow_hub", globals(), "tensorflow_hub")
 
 
 class UniversalSentenceEncoder(SentenceEncoder):

--- a/textattack/goal_functions/__init__.py
+++ b/textattack/goal_functions/__init__.py
@@ -1,7 +1,4 @@
-"""
-
-.. _goal_function:
-
+""".. _goal_function:
 
 Goal functions determine if an attack has been successful.
 ===========================================================

--- a/textattack/goal_functions/text/minimize_bleu.py
+++ b/textattack/goal_functions/text/minimize_bleu.py
@@ -15,7 +15,8 @@ from .text_to_text_goal_function import TextToTextGoalFunction
 
 
 class MinimizeBleu(TextToTextGoalFunction):
-    """Attempts to minimize the BLEU score between the current output translation and the reference translation.
+    """Attempts to minimize the BLEU score between the current output
+    translation and the reference translation.
 
         BLEU score was defined in (BLEU: a Method for Automatic Evaluation of Machine Translation).
 
@@ -28,8 +29,6 @@ class MinimizeBleu(TextToTextGoalFunction):
         `ArxivURL2`_
 
     .. _ArxivURL2: https://www.aclweb.org/anthology/2020.acl-main.263
-
-
     """
 
     EPS = 1e-10

--- a/textattack/loggers/__init__.py
+++ b/textattack/loggers/__init__.py
@@ -1,7 +1,4 @@
-"""
-
-.. _loggers:
-
+""".. _loggers:
 
 Misc Loggers: Loggers track, visualize, and export attack results.
 ===================================================================

--- a/textattack/models/__init__.py
+++ b/textattack/models/__init__.py
@@ -1,5 +1,4 @@
-"""
-.. _models:
+""".. _models:
 
 Models
 =========

--- a/textattack/search_methods/__init__.py
+++ b/textattack/search_methods/__init__.py
@@ -1,13 +1,9 @@
-"""
-
-.. _search_methods:
-
+""".. _search_methods:
 
 Search Methods:
 ===================
 
 Search methods explore the transformation space in an attempt to find a successful attack as determined by a :ref:`Goal Functions <goal_function>` and list of :ref:`Constraints <constraint>`
-
 """
 from .search_method import SearchMethod
 from .beam_search import BeamSearch

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -1,14 +1,9 @@
-"""
-
-.. _attacked_text:
-
+""".. _attacked_text:
 
 Attacked Text Class
 =====================
 
 A helper class that represents a string that can be attacked.
-
-
 """
 
 from collections import OrderedDict

--- a/textattack/shared/utils/__init__.py
+++ b/textattack/shared/utils/__init__.py
@@ -2,3 +2,4 @@ from .install import *
 from .misc import *
 from .strings import *
 from .tensor import *
+from .importing import *

--- a/textattack/shared/utils/importing.py
+++ b/textattack/shared/utils/importing.py
@@ -1,0 +1,44 @@
+# Code copied from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/lazy_loader.py
+from __future__ import absolute_import, division, print_function
+
+import importlib
+import types
+
+
+class LazyLoader(types.ModuleType):
+    """Lazily import a module, mainly to avoid pulling in large dependencies.
+
+    This allows them to only be loaded when they are used.
+    """
+
+    def __init__(self, local_name, parent_module_globals, name):
+        self._local_name = local_name
+        self._parent_module_globals = parent_module_globals
+
+        super(LazyLoader, self).__init__(name)
+
+    def _load(self):
+        """Load the module and insert it into the parent's globals."""
+        # Import the target module and insert it into the parent's namespace
+        try:
+            module = importlib.import_module(self.__name__)
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError(
+                f"Lazy module loader cannot find module named `{self.__name__}`. Please run `pip install {self.__name__}`."
+            ) from e
+        self._parent_module_globals[self._local_name] = module
+
+        # Update this object's dict so that if someone keeps a reference to the
+        #   LazyLoader, lookups are efficient (__getattr__ is only called on lookups
+        #   that fail).
+        self.__dict__.update(module.__dict__)
+
+        return module
+
+    def __getattr__(self, item):
+        module = self._load()
+        return getattr(module, item)
+
+    def __dir__(self):
+        module = self._load()
+        return dir(module)

--- a/textattack/shared/utils/importing.py
+++ b/textattack/shared/utils/importing.py
@@ -1,5 +1,4 @@
 # Code copied from https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/lazy_loader.py
-from __future__ import absolute_import, division, print_function
 
 import importlib
 import types

--- a/textattack/shared/utils/install.py
+++ b/textattack/shared/utils/install.py
@@ -156,4 +156,6 @@ TEXTATTACK_CACHE_DIR = os.environ.get(
 if "TA_CACHE_DIR" in os.environ:
     set_cache_dir(os.environ["TA_CACHE_DIR"])
 
-_post_install_if_needed()
+if not ("TEXTATTACK_DOC_BUILD" in os.environ and os.environ["TEXTATTACK_DOC_BUILD"] == "TRUE"):
+    # Don't do installation when building docs.
+    _post_install_if_needed()

--- a/textattack/shared/utils/install.py
+++ b/textattack/shared/utils/install.py
@@ -156,6 +156,9 @@ TEXTATTACK_CACHE_DIR = os.environ.get(
 if "TA_CACHE_DIR" in os.environ:
     set_cache_dir(os.environ["TA_CACHE_DIR"])
 
-if not ("TEXTATTACK_DOC_BUILD" in os.environ and os.environ["TEXTATTACK_DOC_BUILD"] == "TRUE"):
+if not (
+    "TEXTATTACK_DOC_BUILD" in os.environ
+    and os.environ["TEXTATTACK_DOC_BUILD"] == "TRUE"
+):
     # Don't do installation when building docs.
     _post_install_if_needed()

--- a/textattack/shared/utils/misc.py
+++ b/textattack/shared/utils/misc.py
@@ -17,8 +17,6 @@ def html_style_from_dict(style_dict):
 
     into
         style: "color: red; height: 100px"
-
-
     """
     style_str = ""
     for key in style_dict:

--- a/textattack/transformations/__init__.py
+++ b/textattack/transformations/__init__.py
@@ -1,13 +1,9 @@
-"""
-
-.. _transformations:
-
+""".. _transformations:
 
 Transformations
 ==========================
 
 A transformation is a method which perturbs a text input through the insertion, deletion and substiution of words, characters, and phrases. All transformations take a ``TokenizedText`` as input and return a list of ``TokenizedText`` that contains possible transformations. Every transformation is a subclass of the abstract ``Transformation`` class.
-
 """
 
 from .transformation import Transformation

--- a/textattack/transformations/random_synonym_insertion.py
+++ b/textattack/transformations/random_synonym_insertion.py
@@ -6,7 +6,7 @@ random synonym insertation Transformation
 
 import random
 
-from nltk.corpus import wordnet
+import nltk
 
 from textattack.transformations import Transformation
 
@@ -17,7 +17,7 @@ class RandomSynonymInsertion(Transformation):
 
     def _get_synonyms(self, word):
         synonyms = set()
-        for syn in wordnet.synsets(word):
+        for syn in nltk.corpus.wordnet.synsets(word):
             for lemma in syn.lemmas():
                 if lemma.name() != word and check_if_one_word(lemma.name()):
                     synonyms.add(lemma.name())

--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -21,7 +21,6 @@ class WordSwapInflections(WordSwap):
     `Paper URL`_
 
     .. _Paper URL: https://www.aclweb.org/anthology/2020.acl-main.263.pdf
-
     """
 
     def __init__(self, **kwargs):

--- a/textattack/transformations/word_swap_wordnet.py
+++ b/textattack/transformations/word_swap_wordnet.py
@@ -4,7 +4,7 @@ Word Swap by swaping synonyms in WordNet
 """
 
 
-from nltk.corpus import wordnet
+import nltk
 
 import textattack
 from textattack.transformations.word_swap import WordSwap
@@ -15,15 +15,17 @@ class WordSwapWordNet(WordSwap):
     WordNet."""
 
     def __init__(self, language="eng"):
-        if language not in wordnet.langs():
-            raise ValueError(f"Language {language} not one of {wordnet.langs()}")
+        if language not in nltk.corpus.wordnet.langs():
+            raise ValueError(
+                f"Language {language} not one of {nltk.corpus.wordnet.langs()}"
+            )
         self.language = language
 
     def _get_replacement_words(self, word, random=False):
         """Returns a list containing all possible words with 1 character
         replaced by a homoglyph."""
         synonyms = set()
-        for syn in wordnet.synsets(word, lang=self.language):
+        for syn in nltk.corpus.wordnet.synsets(word, lang=self.language):
             for syn_word in syn.lemma_names(lang=self.language):
                 if (
                     (syn_word != word)


### PR DESCRIPTION
This PR adds lazy loading scheme for modules that are not regularily used by TextAttack (e.g. Tensorflow, stanza). New addition:
- `LazyLoader` class that handles lazy module loading. This is an adaptation from Tensorflow's LazyLoader https://github.com/tensorflow/tensorflow/blob/master/tensorflow/python/util/lazy_loader.py. (Pretty funny we use it to lazy load Tensorflow)
- Lazy load Tensorflow and Tensorflow-related modules.
- Add env variable check that skips installing `nltk` and `stanza` resource downloads when building doc. This also works with readthedocs as I added `TEXTATTACK_DOC_BUILD` env variable to the readthedoc build process. 

This PR is pretty conservative, but we can possibly drop `tensorflow`, `stanza`, `sentence_transformers`, `sckit-learn`, etc. from the requirements.txt

