### PR TITLE
Allow words connected by additional special char

### DIFF
--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -32,7 +32,7 @@ def words_from_text(s, words_to_ignore=[]):
     for c in " ".join(s.split()):
         if c.isalnum():
             word += c
-        elif c in "'-" and len(word) > 0:
+        elif c in "'-_*@" and len(word) > 0:
             # Allow apostrophes and hyphens as long as they don't begin the
             # word.
             word += c

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -33,7 +33,7 @@ def words_from_text(s, words_to_ignore=[]):
         if c.isalnum():
             word += c
         elif c in "'-_*@" and len(word) > 0:
-            # Allow apostrophes and hyphens as long as they don't begin the
+            # Allow apostrophes, hyphens, underscores, asterisks and at signs as long as they don't begin the
             # word.
             word += c
         elif word:


### PR DESCRIPTION
As per https://github.com/QData/TextAttack/issues/325#issuecomment-723136430, some custom embeddings contain words with "_@*" in the vocabulary, it'd be helpful to take this into consideration when tokenizing attacked sentences