### PR TITLE
custom embeddings

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -33,5 +33,5 @@ jobs:
         pip freeze
     - name: Test with pytest
       run: |
-        pytest tests -vx --dist=loadfile -n auto
+        pytest tests -v
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bert-score>=0.3.5
 editdistance
 flair==0.6.1.post1
 filelock
+gensim==3.8.3
 language_tool_python
 lemminflect
 lru-dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ bert-score>=0.3.5
 editdistance
 flair==0.6.1.post1
 filelock
-gensim==3.8.3
 language_tool_python
 lemminflect
 lru-dict

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ extras["optional"] = [
     "stanza",
     "visdom",
     "wandb",
+    "gensim==3.8.3",
 ]
 
 # For developers, install development tools along with all optional dependencies.

--- a/tests/sample_outputs/interactive_mode.txt
+++ b/tests/sample_outputs/interactive_mode.txt
@@ -5,11 +5,11 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  50
-    (embedding_type):  paragramcf
+    (embedding):  TextAttackWordEmbedding
   )
   (constraints): 
     (0): WordEmbeddingDistance(
-        (embedding_type):  paragramcf
+        (embedding):  TextAttackWordEmbedding
         (min_cos_sim):  0.5
         (cased):  False
         (include_unknown_words):  True

--- a/tests/sample_outputs/interactive_mode.txt
+++ b/tests/sample_outputs/interactive_mode.txt
@@ -5,11 +5,11 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  50
-    (embedding):  TextAttackWordEmbedding
+    (embedding):  WordEmbedding
   )
   (constraints): 
     (0): WordEmbeddingDistance(
-        (embedding):  TextAttackWordEmbedding
+        (embedding):  WordEmbedding
         (min_cos_sim):  0.5
         (cased):  False
         (include_unknown_words):  True

--- a/tests/sample_outputs/kuleshov_cnn_sst_2.txt
+++ b/tests/sample_outputs/kuleshov_cnn_sst_2.txt
@@ -3,7 +3,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding_type):  paragramcf
+    (embedding):  TextAttackWordEmbedding
   )
   (constraints): 
     (0): MaxWordsPerturbed(
@@ -11,7 +11,7 @@
         (compare_against_original):  True
       )
     (1): ThoughtVector(
-        (embedding_type):  paragramcf
+        (word_embedding):  TextAttackWordEmbedding
         (metric):  max_euclidean
         (threshold):  -0.2
         (window_size):  inf

--- a/tests/sample_outputs/kuleshov_cnn_sst_2.txt
+++ b/tests/sample_outputs/kuleshov_cnn_sst_2.txt
@@ -3,7 +3,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding):  TextAttackWordEmbedding
+    (embedding):  WordEmbedding
   )
   (constraints): 
     (0): MaxWordsPerturbed(
@@ -11,7 +11,7 @@
         (compare_against_original):  True
       )
     (1): ThoughtVector(
-        (word_embedding):  TextAttackWordEmbedding
+        (word_embedding):  WordEmbedding
         (metric):  max_euclidean
         (threshold):  -0.2
         (window_size):  inf

--- a/tests/sample_outputs/run_attack_faster_alzantot_recipe.txt
+++ b/tests/sample_outputs/run_attack_faster_alzantot_recipe.txt
@@ -10,7 +10,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  8
-    (embedding):  TextAttackWordEmbedding
+    (embedding):  WordEmbedding
   )
   (constraints): 
     (0): MaxWordsPerturbed(
@@ -18,7 +18,7 @@
         (compare_against_original):  True
       )
     (1): WordEmbeddingDistance(
-        (embedding):  TextAttackWordEmbedding
+        (embedding):  WordEmbedding
         (max_mse_dist):  0.5
         (cased):  False
         (include_unknown_words):  True

--- a/tests/sample_outputs/run_attack_faster_alzantot_recipe.txt
+++ b/tests/sample_outputs/run_attack_faster_alzantot_recipe.txt
@@ -10,7 +10,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  8
-    (embedding_type):  paragramcf
+    (embedding):  TextAttackWordEmbedding
   )
   (constraints): 
     (0): MaxWordsPerturbed(
@@ -18,7 +18,7 @@
         (compare_against_original):  True
       )
     (1): WordEmbeddingDistance(
-        (embedding_type):  paragramcf
+        (embedding):  TextAttackWordEmbedding
         (max_mse_dist):  0.5
         (cased):  False
         (include_unknown_words):  True

--- a/tests/sample_outputs/run_attack_flair_pos_tagger_bert_score.txt
+++ b/tests/sample_outputs/run_attack_flair_pos_tagger_bert_score.txt
@@ -5,7 +5,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding_type):  paragramcf
+    (embedding):  TextAttackWordEmbedding
   )
   (constraints): 
     (0): BERTScore(

--- a/tests/sample_outputs/run_attack_flair_pos_tagger_bert_score.txt
+++ b/tests/sample_outputs/run_attack_flair_pos_tagger_bert_score.txt
@@ -5,7 +5,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding):  TextAttackWordEmbedding
+    (embedding):  WordEmbedding
   )
   (constraints): 
     (0): BERTScore(

--- a/tests/sample_outputs/run_attack_gradient_greedy_word_wir.txt
+++ b/tests/sample_outputs/run_attack_gradient_greedy_word_wir.txt
@@ -5,7 +5,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding):  TextAttackWordEmbedding
+    (embedding):  WordEmbedding
   )
   (constraints): 
     (0): RepeatModification

--- a/tests/sample_outputs/run_attack_gradient_greedy_word_wir.txt
+++ b/tests/sample_outputs/run_attack_gradient_greedy_word_wir.txt
@@ -5,7 +5,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding_type):  paragramcf
+    (embedding):  TextAttackWordEmbedding
   )
   (constraints): 
     (0): RepeatModification

--- a/tests/sample_outputs/run_attack_hotflip_lstm_mr_4.txt
+++ b/tests/sample_outputs/run_attack_hotflip_lstm_mr_4.txt
@@ -12,7 +12,7 @@
         (compare_against_original):  True
       )
     (1): WordEmbeddingDistance(
-        (embedding):  TextAttackWordEmbedding
+        (embedding):  WordEmbedding
         (min_cos_sim):  0.8
         (cased):  False
         (include_unknown_words):  True

--- a/tests/sample_outputs/run_attack_hotflip_lstm_mr_4.txt
+++ b/tests/sample_outputs/run_attack_hotflip_lstm_mr_4.txt
@@ -12,7 +12,7 @@
         (compare_against_original):  True
       )
     (1): WordEmbeddingDistance(
-        (embedding_type):  paragramcf
+        (embedding):  TextAttackWordEmbedding
         (min_cos_sim):  0.8
         (cased):  False
         (include_unknown_words):  True

--- a/tests/sample_outputs/run_attack_stanza_pos_tagger.txt
+++ b/tests/sample_outputs/run_attack_stanza_pos_tagger.txt
@@ -3,7 +3,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding_type):  paragramcf
+    (embedding):  TextAttackWordEmbedding
   )
   (constraints): 
     (0): PartOfSpeech(

--- a/tests/sample_outputs/run_attack_stanza_pos_tagger.txt
+++ b/tests/sample_outputs/run_attack_stanza_pos_tagger.txt
@@ -3,7 +3,7 @@
   (goal_function):  UntargetedClassification
   (transformation):  WordSwapEmbedding(
     (max_candidates):  15
-    (embedding):  TextAttackWordEmbedding
+    (embedding):  WordEmbedding
   )
   (constraints): 
     (0): PartOfSpeech(

--- a/tests/test_word_embedding.py
+++ b/tests/test_word_embedding.py
@@ -3,11 +3,11 @@ import os
 import numpy as np
 import pytest
 
-from textattack.shared import GensimWordEmbedding, TextAttackWordEmbedding
+from textattack.shared import GensimWordEmbedding, WordEmbedding
 
 
 def test_embedding_paragramcf():
-    word_embedding = TextAttackWordEmbedding.counterfitted_GLOVE_embedding()
+    word_embedding = WordEmbedding.counterfitted_GLOVE_embedding()
     assert pytest.approx(word_embedding[0][0]) == -0.022007
     assert pytest.approx(word_embedding["fawn"][0]) == -0.022007
     assert word_embedding[10 ** 9] is None

--- a/tests/test_word_embedding.py
+++ b/tests/test_word_embedding.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 
@@ -5,21 +7,39 @@ from textattack.shared import WordEmbedding
 
 
 def test_embedding_paragramcf():
-    word_embedding = WordEmbedding(embedding_type="paragramcf")
+    word_embedding = WordEmbedding()
     assert pytest.approx(word_embedding[0][0]) == -0.022007
     assert pytest.approx(word_embedding["fawn"][0]) == -0.022007
     assert word_embedding[10 ** 9] is None
 
 
-def test_embedding_or_type_required():
-    with pytest.raises(ValueError):
-        WordEmbedding(embedding_type=None, embeddings=None)
+def test_embedding_gensim():
+    # download a trained word2vec model
+    from textattack.shared.utils.install import TEXTATTACK_CACHE_DIR
 
-
-def test_embedding_custom_lookup():
-    embs = np.array([[0, 1, 2], [3, 4, 5]])
-    word2index = {"hello": 0, "world": 1}
-    word_embedding = WordEmbedding(embeddings=embs, word2index=word2index)
-    assert pytest.approx(word_embedding[1][0]) == 3
-    assert pytest.approx(word_embedding["world"][0]) == 3
+    path = os.path.join(TEXTATTACK_CACHE_DIR, "test_gensim_embedding.txt")
+    f = open(path, "w")
+    f.write(
+        """4 2
+hi 1 0
+hello 1 1
+bye -1 0
+bye-bye -1 1
+    """
+    )
+    f.close()
+    word_embedding = WordEmbedding(embedding_type=path, embedding_source="gensim")
+    assert pytest.approx(word_embedding[0][0]) == 1
+    assert pytest.approx(word_embedding["bye-bye"][0]) == -1 / np.sqrt(2)
     assert word_embedding[10 ** 9] is None
+
+    # test query functionality
+    assert pytest.approx(word_embedding.get_cos_sim(1, 3)) == 0
+    # mse dist
+    assert pytest.approx(word_embedding.get_mse_dist(0, 2)) == 4
+    # nearest neighbour of hi is hello
+    assert word_embedding.nn(0, 1)[0] == 1
+    assert word_embedding.word2ind("bye") == 2
+    assert word_embedding.ind2word(3) == "bye-bye"
+    # remove test file
+    os.remove(path)

--- a/tests/test_word_embedding.py
+++ b/tests/test_word_embedding.py
@@ -3,11 +3,11 @@ import os
 import numpy as np
 import pytest
 
-from textattack.shared import WordEmbedding
+from textattack.shared import GensimWordEmbedding, TextAttackWordEmbedding
 
 
 def test_embedding_paragramcf():
-    word_embedding = WordEmbedding()
+    word_embedding = TextAttackWordEmbedding.counterfitted_GLOVE_embedding()
     assert pytest.approx(word_embedding[0][0]) == -0.022007
     assert pytest.approx(word_embedding["fawn"][0]) == -0.022007
     assert word_embedding[10 ** 9] is None
@@ -28,7 +28,7 @@ bye-bye -1 1
     """
     )
     f.close()
-    word_embedding = WordEmbedding(embedding_type=path, embedding_source="gensim")
+    word_embedding = GensimWordEmbedding(path)
     assert pytest.approx(word_embedding[0][0]) == 1
     assert pytest.approx(word_embedding["bye-bye"][0]) == -1 / np.sqrt(2)
     assert word_embedding[10 ** 9] is None
@@ -38,8 +38,8 @@ bye-bye -1 1
     # mse dist
     assert pytest.approx(word_embedding.get_mse_dist(0, 2)) == 4
     # nearest neighbour of hi is hello
-    assert word_embedding.nn(0, 1)[0] == 1
-    assert word_embedding.word2ind("bye") == 2
-    assert word_embedding.ind2word(3) == "bye-bye"
+    assert word_embedding.nearest_neighbours(0, 1)[0] == 1
+    assert word_embedding.word2index("bye") == 2
+    assert word_embedding.index2word(3) == "bye-bye"
     # remove test file
     os.remove(path)

--- a/textattack/attack_recipes/kuleshov_2017.py
+++ b/textattack/attack_recipes/kuleshov_2017.py
@@ -49,11 +49,7 @@ class Kuleshov2017(AttackRecipe):
         #
         # Maximum thought vector Euclidean distance of λ_1 = 0.2. (eq. 4)
         #
-        constraints.append(
-            ThoughtVector(
-                embedding_type="paragramcf", threshold=0.2, metric="max_euclidean"
-            )
-        )
+        constraints.append(ThoughtVector(threshold=0.2, metric="max_euclidean"))
         #
         #
         # Maximum language model log-probability difference of λ_2 = 2. (eq. 5)

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -115,9 +115,7 @@ class EmbeddingAugmenter(Augmenter):
     def __init__(self, **kwargs):
         from textattack.transformations import WordSwapEmbedding
 
-        transformation = WordSwapEmbedding(
-            max_candidates=50, embedding_type="paragramcf"
-        )
+        transformation = WordSwapEmbedding(max_candidates=50)
         from textattack.constraints.semantics import WordEmbeddingDistance
 
         constraints = DEFAULT_CONSTRAINTS + [WordEmbeddingDistance(min_cos_sim=0.8)]

--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -21,8 +21,8 @@ class ThoughtVector(SentenceEncoder):
         max_mse_dist: the maximum euclidean distance between thought vectors
     """
 
-    def __init__(self, embedding_type="paragramcf", **kwargs):
-        self.word_embedding = WordEmbedding(embedding_type)
+    def __init__(self, embedding_type="paragramcf", embedding_source=None, **kwargs):
+        self.word_embedding = WordEmbedding(embedding_type, embedding_source)
         self.embedding_type = embedding_type
         super().__init__(**kwargs)
 

--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -7,7 +7,7 @@ import functools
 
 import torch
 
-from textattack.shared import WordEmbedding, utils
+from textattack.shared import TextAttackWordEmbedding, WordEmbedding, utils
 
 from .sentence_encoder import SentenceEncoder
 
@@ -16,14 +16,19 @@ class ThoughtVector(SentenceEncoder):
     """A constraint on the distance between two sentences' thought vectors.
 
     Args:
-        word_embedding (str): The word embedding to use
-        min_cos_sim: the minimum cosine similarity between thought vectors
-        max_mse_dist: the maximum euclidean distance between thought vectors
+        word_embedding (textattack.shared.WordEmbedding): The word embedding to use
     """
 
-    def __init__(self, embedding_type="paragramcf", embedding_source=None, **kwargs):
-        self.word_embedding = WordEmbedding(embedding_type, embedding_source)
-        self.embedding_type = embedding_type
+    def __init__(
+        self,
+        embedding=TextAttackWordEmbedding.counterfitted_GLOVE_embedding(),
+        **kwargs
+    ):
+        if not isinstance(embedding, WordEmbedding):
+            raise ValueError(
+                "`embedding` object must be of type `textattack.shared.WordEmbedding`."
+            )
+        self.word_embedding = embedding
         super().__init__(**kwargs)
 
     def clear_cache(self):
@@ -46,4 +51,4 @@ class ThoughtVector(SentenceEncoder):
 
     def extra_repr_keys(self):
         """Set the extra representation of the constraint using these keys."""
-        return ["embedding_type"] + super().extra_repr_keys()
+        return ["word_embedding"] + super().extra_repr_keys()

--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -7,7 +7,7 @@ import functools
 
 import torch
 
-from textattack.shared import TextAttackWordEmbedding, WordEmbedding, utils
+from textattack.shared import AbstractWordEmbedding, WordEmbedding, utils
 
 from .sentence_encoder import SentenceEncoder
 
@@ -16,17 +16,15 @@ class ThoughtVector(SentenceEncoder):
     """A constraint on the distance between two sentences' thought vectors.
 
     Args:
-        word_embedding (textattack.shared.WordEmbedding): The word embedding to use
+        word_embedding (textattack.shared.AbstractWordEmbedding): The word embedding to use
     """
 
     def __init__(
-        self,
-        embedding=TextAttackWordEmbedding.counterfitted_GLOVE_embedding(),
-        **kwargs
+        self, embedding=WordEmbedding.counterfitted_GLOVE_embedding(), **kwargs
     ):
-        if not isinstance(embedding, WordEmbedding):
+        if not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
-                "`embedding` object must be of type `textattack.shared.WordEmbedding`."
+                "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )
         self.word_embedding = embedding
         super().__init__(**kwargs)

--- a/textattack/constraints/semantics/word_embedding_distance.py
+++ b/textattack/constraints/semantics/word_embedding_distance.py
@@ -4,7 +4,7 @@ Word Embedding Distance
 """
 
 from textattack.constraints import Constraint
-from textattack.shared import TextAttackWordEmbedding, WordEmbedding
+from textattack.shared import AbstractWordEmbedding, WordEmbedding
 from textattack.shared.validators import transformation_consists_of_word_swaps
 
 
@@ -24,7 +24,7 @@ class WordEmbeddingDistance(Constraint):
 
     def __init__(
         self,
-        embedding=TextAttackWordEmbedding.counterfitted_GLOVE_embedding(),
+        embedding=WordEmbedding.counterfitted_GLOVE_embedding(),
         include_unknown_words=True,
         min_cos_sim=None,
         max_mse_dist=None,
@@ -40,9 +40,9 @@ class WordEmbeddingDistance(Constraint):
         self.min_cos_sim = min_cos_sim
         self.max_mse_dist = max_mse_dist
 
-        if not isinstance(embedding, WordEmbedding):
+        if not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
-                "`embedding` object must be of type `textattack.shared.WordEmbedding`."
+                "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )
         self.embedding = embedding
 

--- a/textattack/shared/__init__.py
+++ b/textattack/shared/__init__.py
@@ -13,6 +13,6 @@ from .utils import logger
 from . import validators
 
 from .attacked_text import AttackedText
-from .word_embedding import WordEmbedding
+from .word_embedding import *
 from .attack import Attack
 from .checkpoint import Checkpoint

--- a/textattack/shared/utils/misc.py
+++ b/textattack/shared/utils/misc.py
@@ -122,3 +122,6 @@ def hashable(key):
 
 def sigmoid(n):
     return 1 / (1 + np.exp(-n))
+
+
+GLOBAL_OBJECTS = {}

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -49,15 +49,18 @@ def words_from_text(s, words_to_ignore=[]):
 
 
 def default_class_repr(self):
-    extra_params = []
-    for key in self.extra_repr_keys():
-        extra_params.append("  (" + key + ")" + ":  {" + key + "}")
-    if len(extra_params):
-        extra_str = "\n" + "\n".join(extra_params) + "\n"
-        extra_str = f"({extra_str})"
+    if hasattr(self, "extra_repr_keys"):
+        extra_params = []
+        for key in self.extra_repr_keys():
+            extra_params.append("  (" + key + ")" + ":  {" + key + "}")
+        if len(extra_params):
+            extra_str = "\n" + "\n".join(extra_params) + "\n"
+            extra_str = f"({extra_str})"
+        else:
+            extra_str = ""
+        extra_str = extra_str.format(**self.__dict__)
     else:
         extra_str = ""
-    extra_str = extra_str.format(**self.__dict__)
     return f"{self.__class__.__name__}{extra_str}"
 
 

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -3,12 +3,15 @@ Shared loads word embeddings and related distances
 =====================================================
 """
 
+from collections import defaultdict
 import os
 import pickle
 
 import numpy as np
+import torch
 
 import textattack
+from textattack.shared import utils
 
 
 class WordEmbedding:
@@ -16,42 +19,57 @@ class WordEmbedding:
 
     Args:
         embedding_type (str): The type of the embedding to load automatically
-        embeddings: A dictionary or matrix that maps word embeddings from
-            their IDs to vectors (torch tensors or numpy ndarrays). Must be
-            provided for custom embeddings, when embedding_type is not provided.
-            If both `embedding_type` and `embeddings` are provided, `embeddings`
-            overrides `embedding_type`.
-        word2index: A dictionary that maps words by string to ID. Not required,
-            but useful if the user intends to use this class to look up word
-            embeddings by their string. Can omit this argument and solely query
-            words by ID from `self.embeddings`.
+        embedding_source (str): Source of embeddings provided,
+        "defaults" corresponds to the textattack s3 bucket
+        "gensim" expects a word2vec model
     """
 
     PATH = "word_embeddings"
+    EMBEDDINGS_AVAILABLE_IN_TEXTATTACK = {"paragramcf"}
 
-    def __init__(self, embedding_type="paragramcf", embeddings=None, word2index=None):
-        if embeddings is not None:
-            self.embeddings = embeddings
-            self.word2index = word2index or {}
-        elif embedding_type:
-            self._init_embeddings_from_type(embedding_type)
-        else:
-            raise ValueError(
-                "Must supply `embedding_type` or `embeddings` as parameters."
-            )
+    def __init__(self, embedding_type=None, embedding_source=None):
 
-    def _init_embeddings_from_type(self, embedding_type):
-        """Initializes self.embeddings based on the type of embedding.
+        self.embedding_type = embedding_type or "paragramcf"
+        self.embedding_source = embedding_source or "defaults"
 
-        Downloads and loads embeddings into memory.
+        if self.embedding_source == "defaults":
+            if (
+                self.embedding_type
+                not in WordEmbedding.EMBEDDINGS_AVAILABLE_IN_TEXTATTACK
+            ):
+                raise ValueError(
+                    f"{self.embedding_type} is not available in TextAttack."
+                )
+        elif self.embedding_source not in ["gensim"]:
+            raise ValueError(f"{self.embedding_source} type is not supported.")
+
+        self._embeddings = None
+        self._word2index = None
+        self._index2word = None
+        self._cos_sim_mat = None
+        self._mse_dist_mat = None
+        self._nn = None
+
+        self._gensim_keyed_vectors = None
+
+        self._init_embeddings_from_type(self.embedding_source, self.embedding_type)
+
+    def _init_embeddings_from_defaults(self, embedding_type):
         """
-        self.embedding_type = embedding_type
+        Init embeddings prepared in the textattack s3 bucket
+        Args:
+            embedding_type:
+
+        Returns:
+
+        """
         if embedding_type == "paragramcf":
             word_embeddings_folder = "paragramcf"
             word_embeddings_file = "paragram.npy"
             word_list_file = "wordlist.pickle"
             mse_dist_file = "mse_dist.p"
             cos_sim_file = "cos_sim.p"
+            nn_matrix_file = "nn.npy"
         else:
             raise ValueError(f"Could not find word embedding {embedding_type}")
 
@@ -70,36 +88,237 @@ class WordEmbedding:
         word_list_file = os.path.join(word_embeddings_folder, word_list_file)
         mse_dist_file = os.path.join(word_embeddings_folder, mse_dist_file)
         cos_sim_file = os.path.join(word_embeddings_folder, cos_sim_file)
+        nn_matrix_file = os.path.join(word_embeddings_folder, nn_matrix_file)
 
-        # Actually load the files from disk.
-        self.embeddings = np.load(word_embeddings_file)
-        self.word2index = np.load(word_list_file, allow_pickle=True)
-
-        # Precomputed distance matrices store distances at mat[x][y], where
-        # x and y are word IDs and x < y.
+        # loading the files
+        self._embeddings = np.load(word_embeddings_file)
+        self._word2index = np.load(word_list_file, allow_pickle=True)
         if os.path.exists(mse_dist_file):
             with open(mse_dist_file, "rb") as f:
-                self.mse_dist_mat = pickle.load(f)
+                self._mse_dist_mat = pickle.load(f)
         else:
-            self.mse_dist_mat = {}
+            self._mse_dist_mat = defaultdict(dict)
         if os.path.exists(cos_sim_file):
             with open(cos_sim_file, "rb") as f:
-                self.cos_sim_mat = pickle.load(f)
+                self._cos_sim_mat = pickle.load(f)
         else:
-            self.cos_sim_mat = {}
+            self._cos_sim_mat = defaultdict(dict)
+
+        self._nn = np.load(nn_matrix_file)
+
+        # Build glove dict and index.
+        self._index2word = dict()
+        for word, index in self._word2index.items():
+            self._index2word[index] = word
+
+    def _init_embeddings_from_gensim(self, embedding_type):
+        """
+        Initialize word embedding from a gensim word2vec model
+        Args:
+            embedding_type:
+
+        Returns:
+
+        """
+        import gensim
+
+        if embedding_type.endswith(".bin"):
+            self._gensim_keyed_vectors = (
+                gensim.models.KeyedVectors.load_word2vec_format(
+                    embedding_type, binary=True
+                )
+            )
+        else:
+            self._gensim_keyed_vectors = (
+                gensim.models.KeyedVectors.load_word2vec_format(embedding_type)
+            )
+        self._gensim_keyed_vectors.init_sims()
+
+    def _init_embeddings_from_type(self, embedding_source, embedding_type):
+        """Initializes embedding based on the source.
+
+        Downloads and loads embeddings into memory.
+        """
+
+        if embedding_source == "defaults":
+            self._init_embeddings_from_defaults(embedding_type)
+        elif embedding_source == "gensim":
+            self._init_embeddings_from_gensim(embedding_type)
+        else:
+            raise ValueError(f"Not supported word embedding source {embedding_source}")
 
     def __getitem__(self, index):
         """Gets a word embedding by word or ID.
 
         If word or ID not found, returns None.
         """
-        if isinstance(index, str):
+        if self.embedding_source == "defaults":
+            if isinstance(index, str):
+                try:
+                    index = self._word2index[index]
+                except KeyError:
+                    return None
             try:
-                index = self.word2index[index]
-            except KeyError:
+                return self._embeddings[index]
+            except IndexError:
+                # word embedding ID out of bounds
                 return None
-        try:
-            return self.embeddings[index]
-        except IndexError:
-            # word embedding ID out of bounds
-            return None
+        elif self.embedding_source == "gensim":
+            if isinstance(index, str):
+                try:
+                    index = self._gensim_keyed_vectors.vocab.get(index).index
+                except KeyError:
+                    return None
+            try:
+                return self._gensim_keyed_vectors.vectors_norm[index]
+            except IndexError:
+                # word embedding ID out of bounds
+                return None
+        else:
+            raise ValueError(
+                f"Not supported word embedding source {self.embedding_source}"
+            )
+
+    def get_cos_sim(self, a, b):
+        """
+        get cosine similarity of two words/IDs
+        Args:
+            a:
+            b:
+
+        Returns:
+
+        """
+        if self.embedding_source == "defaults":
+            if isinstance(a, str):
+                a = self._word2index[a]
+            if isinstance(b, str):
+                b = self._word2index[b]
+            a, b = min(a, b), max(a, b)
+            try:
+                cos_sim = self._cos_sim_mat[a][b]
+            except KeyError:
+                e1 = self._embeddings[a]
+                e2 = self._embeddings[b]
+                e1 = torch.tensor(e1).to(utils.device)
+                e2 = torch.tensor(e2).to(utils.device)
+                cos_sim = torch.nn.CosineSimilarity(dim=0)(e1, e2).item()
+                self._cos_sim_mat[a][b] = cos_sim
+            return cos_sim
+        elif self.embedding_source == "gensim":
+            if not isinstance(a, str):
+                a = self._gensim_keyed_vectors.index2word[a]
+            if not isinstance(b, str):
+                b = self._gensim_keyed_vectors.index2word[b]
+            cos_sim = self._gensim_keyed_vectors.similarity(a, b)
+            return cos_sim
+        else:
+            raise ValueError(
+                f"Not supported word embedding source {self.embedding_source}"
+            )
+
+    def get_mse_dist(self, a, b):
+        """
+        get mse distance of two IDs
+        Args:
+            a:
+            b:
+
+        Returns:
+
+        """
+        if self.embedding_source == "defaults":
+            a, b = min(a, b), max(a, b)
+            try:
+                mse_dist = self._mse_dist_mat[a][b]
+            except KeyError:
+                e1 = self._embeddings[a]
+                e2 = self._embeddings[b]
+                e1 = torch.tensor(e1).to(utils.device)
+                e2 = torch.tensor(e2).to(utils.device)
+                mse_dist = torch.sum((e1 - e2) ** 2).item()
+                self._mse_dist_mat[a][b] = mse_dist
+            return mse_dist
+        elif self.embedding_source == "gensim":
+            if self._mse_dist_mat is None:
+                self._mse_dist_mat = defaultdict(dict)
+            try:
+                mse_dist = self._mse_dist_mat[a][b]
+            except KeyError:
+                e1 = self._gensim_keyed_vectors.vectors_norm[a]
+                e2 = self._gensim_keyed_vectors.vectors_norm[b]
+                e1 = torch.tensor(e1).to(utils.device)
+                e2 = torch.tensor(e2).to(utils.device)
+                mse_dist = torch.sum((e1 - e2) ** 2).item()
+                self._mse_dist_mat[a][b] = mse_dist
+            return mse_dist
+        else:
+            raise ValueError(
+                f"Not supported word embedding source {self.embedding_source}"
+            )
+
+    def word2ind(self, word):
+        """
+        word to index
+        Args:
+            word:
+
+        Returns:
+
+        """
+        if self.embedding_source == "defaults":
+            return self._word2index[word]
+        elif self.embedding_source == "gensim":
+            vocab = self._gensim_keyed_vectors.vocab.get(word)
+            if vocab is None:
+                raise KeyError(word)
+            return vocab.index
+        else:
+            raise ValueError(
+                f"Not supported word embedding source {self.embedding_source}"
+            )
+
+    def ind2word(self, index):
+        """
+        index to word
+        Args:
+            index:
+
+        Returns:
+
+        """
+        if self.embedding_source == "defaults":
+            return self._index2word[index]
+        elif self.embedding_source == "gensim":
+            try:
+                # this is a list, so the error would be IndexError
+                return self._gensim_keyed_vectors.index2word[index]
+            except IndexError:
+                raise KeyError(index)
+        else:
+            raise ValueError(
+                f"Not supported word embedding source {self.embedding_source}"
+            )
+
+    def nn(self, index, topn):
+        """
+        get top n nearest neighbours for a word
+        Args:
+            index:
+            topn:
+
+        Returns:
+
+        """
+        if self.embedding_source == "defaults":
+            return self._nn[index][1 : (topn + 1)]
+        elif self.embedding_source == "gensim":
+            word = self._gensim_keyed_vectors.index2word[index]
+            return [
+                self._gensim_keyed_vectors.index2word.index(i[0])
+                for i in self._gensim_keyed_vectors.similar_by_word(word, topn)
+            ]
+        else:
+            raise ValueError(
+                f"Not supported word embedding source {self.embedding_source}"
+            )

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -20,9 +20,9 @@ class WordEmbedding(ABC):
     This class specifies all the methods that is required to be defined
     so that it can be used for transformation and constraints. For
     custom word embedding not supported by TextAttack, please create a
-    class that inherits this object and implement the required methods.
-    However, please first check if you can use TextAttackWordEmbedding
-    object, which has a lot of internal methods implemented.
+    class that inherits this class and implement the required methods.
+    However, please first check if you can use `TextAttackWordEmbedding`
+    class, which has a lot of internal methods implemented.
     """
 
     @abstractmethod
@@ -37,8 +37,8 @@ class WordEmbedding(ABC):
 
     @abstractmethod
     def get_mse_dist(self, a, b):
-        """Return MSE (i.e. L2-norm) distance between vector for word `a` and
-        vector for word `b`.
+        """Return MSE distance between vector for word `a` and vector for word
+        `b`.
 
         Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
         Args:
@@ -101,17 +101,17 @@ class WordEmbedding(ABC):
 
 
 class TextAttackWordEmbedding(WordEmbedding):
-    """An object that loads word embeddings and related distances for
-    TextAttack This has a lot of internal components (e.g. get consine
-    similarity) implemented. Consider using this class if you can provide the
-    appropriate input data to create the object.
+    """Object for loading word embeddings and related distances for TextAttack.
+    This class has a lot of internal components (e.g. get consine similarity)
+    implemented. Consider using this class if you can provide the appropriate
+    input data to create the object.
 
     Args:
-        emedding_matrix (ndarray): 2-D array of NxD where N represents size of vocab and D is the dimension of embedding vectors.
+        emedding_matrix (ndarray): 2-D array of shape N x D where N represents size of vocab and D is the dimension of embedding vectors.
         word2index (Union[dict|object]): dictionary (or a similar object) that maps word to its index with in the embedding matrix.
         index2word (Union[dict|object]): dictionary (or a similar object) that maps index to its word.
-        nn_matrix (ndarray): Matrix for precomputed nearest neighbours matrix. It should be a 2-D integer array of NxK
-            where N represents size of vocab and K is the top-K nearest neighbours. If this is not defined, we have to compute nearest neighbours
+        nn_matrix (ndarray): Matrix for precomputed nearest neighbours. It should be a 2-D integer array of shape N x K
+            where N represents size of vocab and K is the top-K nearest neighbours. If this is set to `None`, we have to compute nearest neighbours
             on the fly for `nearest_neighbours` method, which is costly.
     """
 
@@ -168,8 +168,8 @@ class TextAttackWordEmbedding(WordEmbedding):
         return self._index2word[index]
 
     def get_mse_dist(self, a, b):
-        """Return MSE (i.e. L2-norm) distance between vector for word `a` and
-        vector for word `b`.
+        """Return MSE distance between vector for word `a` and vector for word
+        `b`.
 
         Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
         Args:
@@ -253,6 +253,16 @@ class TextAttackWordEmbedding(WordEmbedding):
         """Returns a prebuilt counter-fitted GLOVE word embedding proposed by
         "Counter-fitting Word Vectors to Linguistic Constraints" (Mrkšić et
         al., 2016)"""
+        if (
+            "textattack_counterfitted_GLOVE_embedding" in utils.GLOBAL_OBJECTS
+            and isinstance(
+                utils.GLOBAL_OBJECTS["textattack_counterfitted_GLOVE_embedding"],
+                TextAttackWordEmbedding,
+            )
+        ):
+            # avoid recreating same embedding (same memory) and instead share across different components
+            return utils.GLOBAL_OBJECTS["textattack_counterfitted_GLOVE_embedding"]
+
         word_embeddings_folder = "paragramcf"
         word_embeddings_file = "paragram.npy"
         word_list_file = "wordlist.pickle"
@@ -282,22 +292,25 @@ class TextAttackWordEmbedding(WordEmbedding):
             index2word[index] = word
         nn_matrix = np.load(nn_matrix_file)
 
-        word_embedding = TextAttackWordEmbedding(
+        embedding = TextAttackWordEmbedding(
             embedding_matrix, word2index, index2word, nn_matrix
         )
+
         with open(mse_dist_file, "rb") as f:
             mse_dist_mat = pickle.load(f)
         with open(cos_sim_file, "rb") as f:
             cos_sim_mat = pickle.load(f)
 
-        word_embedding._mse_dist_mat = mse_dist_mat
-        word_embedding._cos_sim_mat = cos_sim_mat
+        embedding._mse_dist_mat = mse_dist_mat
+        embedding._cos_sim_mat = cos_sim_mat
 
-        return word_embedding
+        utils.GLOBAL_OBJECTS["textattack_counterfitted_GLOVE_embedding"] = embedding
+
+        return embedding
 
 
 class GensimWordEmbedding(WordEmbedding):
-    """Wraps Gensim's KeyedVectors
+    """Wraps Gensim's `KeyedVectors`
     (https://radimrehurek.com/gensim/models/keyedvectors.html)"""
 
     def __init__(self, keyed_vectors_or_path):
@@ -371,8 +384,8 @@ class GensimWordEmbedding(WordEmbedding):
             raise KeyError(index)
 
     def get_mse_dist(self, a, b):
-        """Return MSE (i.e. L2-norm) distance between vector for word `a` and
-        vector for word `b`.
+        """Return MSE distance between vector for word `a` and vector for word
+        `b`.
 
         Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
         Args:

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -3,6 +3,7 @@ Shared loads word embeddings and related distances
 =====================================================
 """
 
+from abc import ABC, abstractmethod
 from collections import defaultdict
 import os
 import pickle
@@ -10,77 +11,260 @@ import pickle
 import numpy as np
 import torch
 
-import textattack
 from textattack.shared import utils
 
 
-class WordEmbedding:
-    """An object that loads word embeddings and related distances.
+class WordEmbedding(ABC):
+    """Abstract class representing word embedding used by TextAttack.
+
+    This class specifies all the methods that is required to be defined
+    so that it can be used for transformation and constraints. For
+    custom word embedding not supported by TextAttack, please create a
+    class that inherits this object and implement the required methods.
+    However, please first check if you can use TextAttackWordEmbedding
+    object, which has a lot of internal methods implemented.
+    """
+
+    @abstractmethod
+    def __getitem__(self, index):
+        """Gets the embedding vector for word/id
+        Args:
+            index (Union[str|int]): `index` can either be word or integer representing the id of the word.
+        Returns:
+            vector (ndarray): 1-D embedding vector. If corresponding vector cannot be found for `index`, returns `None`.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_mse_dist(self, a, b):
+        """Return MSE (i.e. L2-norm) distance between vector for word `a` and
+        vector for word `b`.
+
+        Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
+        Args:
+            a (Union[str|int]): Either word or integer presenting the id of the word
+            b (Union[str|int]): Either word or integer presenting the id of the word
+        Returns:
+            distance (float): MSE (L2) distance
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_cos_sim(self, a, b):
+        """Return cosine similarity between vector for word `a` and vector for
+        word `b`.
+
+        Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
+        Args:
+            a (Union[str|int]): Either word or integer presenting the id of the word
+            b (Union[str|int]): Either word or integer presenting the id of the word
+        Returns:
+            distance (float): cosine similarity
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def word2index(self, word):
+        """
+        Convert between word to id (i.e. index of word in embedding matrix)
+        Args:
+            word (str)
+        Returns:
+            index (int)
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def index2word(self, index):
+        """
+        Convert index to corresponding word
+        Args:
+            index (int)
+        Returns:
+            word (str)
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def nearest_neighbours(self, index, topn):
+        """
+        Get top-N nearest neighbours for a word
+        Args:
+            index (int): ID of the word for which we're finding the nearest neighbours
+            topn (int): Used for specifying N nearest neighbours
+        Returns:
+            neighbours (list[int]): List of indices of the nearest neighbours
+        """
+        raise NotImplementedError()
+
+    __repr__ = __str__ = utils.default_class_repr
+
+
+class TextAttackWordEmbedding(WordEmbedding):
+    """An object that loads word embeddings and related distances for
+    TextAttack This has a lot of internal components (e.g. get consine
+    similarity) implemented. Consider using this class if you can provide the
+    appropriate input data to create the object.
 
     Args:
-        embedding_type (str): The type of the embedding to load automatically
-        embedding_source (str): Source of embeddings provided,
-        "defaults" corresponds to the textattack s3 bucket
-        "gensim" expects a word2vec model
+        emedding_matrix (ndarray): 2-D array of NxD where N represents size of vocab and D is the dimension of embedding vectors.
+        word2index (Union[dict|object]): dictionary (or a similar object) that maps word to its index with in the embedding matrix.
+        index2word (Union[dict|object]): dictionary (or a similar object) that maps index to its word.
+        nn_matrix (ndarray): Matrix for precomputed nearest neighbours matrix. It should be a 2-D integer array of NxK
+            where N represents size of vocab and K is the top-K nearest neighbours. If this is not defined, we have to compute nearest neighbours
+            on the fly for `nearest_neighbours` method, which is costly.
     """
 
     PATH = "word_embeddings"
-    EMBEDDINGS_AVAILABLE_IN_TEXTATTACK = {"paragramcf"}
 
-    def __init__(self, embedding_type=None, embedding_source=None):
+    def __init__(self, embedding_matrix, word2index, index2word, nn_matrix=None):
+        self.embedding_matrix = embedding_matrix
+        self._word2index = word2index
+        self._index2word = index2word
+        self.nn_matrix = nn_matrix
 
-        self.embedding_type = embedding_type or "paragramcf"
-        self.embedding_source = embedding_source or "defaults"
+        # Dictionary for caching results
+        self._mse_dist_mat = defaultdict(dict)
+        self._cos_sim_mat = defaultdict(dict)
+        self._nn_cache = {}
 
-        if self.embedding_source == "defaults":
-            if (
-                self.embedding_type
-                not in WordEmbedding.EMBEDDINGS_AVAILABLE_IN_TEXTATTACK
-            ):
-                raise ValueError(
-                    f"{self.embedding_type} is not available in TextAttack."
-                )
-        elif self.embedding_source not in ["gensim"]:
-            raise ValueError(f"{self.embedding_source} type is not supported.")
-
-        self._embeddings = None
-        self._word2index = None
-        self._index2word = None
-        self._cos_sim_mat = None
-        self._mse_dist_mat = None
-        self._nn = None
-
-        self._gensim_keyed_vectors = None
-
-        self._init_embeddings_from_type(self.embedding_source, self.embedding_type)
-
-    def _init_embeddings_from_defaults(self, embedding_type):
-        """
-        Init embeddings prepared in the textattack s3 bucket
+    def __getitem__(self, index):
+        """Gets the embedding vector for word/id
         Args:
-            embedding_type:
-
+            index (Union[str|int]): `index` can either be word or integer representing the id of the word.
         Returns:
+            vector (ndarray): 1-D embedding vector. If corresponding vector cannot be found for `index`, returns `None`.
+        """
+        if isinstance(index, str):
+            try:
+                index = self._word2index[index]
+            except KeyError:
+                return None
+        try:
+            return self.embedding_matrix[index]
+        except IndexError:
+            # word embedding ID out of bounds
+            return None
+
+    def word2index(self, word):
+        """
+        Convert between word to id (i.e. index of word in embedding matrix)
+        Args:
+            word (str)
+        Returns:
+            index (int)
+        """
+        return self._word2index[word]
+
+    def index2word(self, index):
+        """
+        Convert index to corresponding word
+        Args:
+            index (int)
+        Returns:
+            word (str)
 
         """
-        if embedding_type == "paragramcf":
-            word_embeddings_folder = "paragramcf"
-            word_embeddings_file = "paragram.npy"
-            word_list_file = "wordlist.pickle"
-            mse_dist_file = "mse_dist.p"
-            cos_sim_file = "cos_sim.p"
-            nn_matrix_file = "nn.npy"
+        return self._index2word[index]
+
+    def get_mse_dist(self, a, b):
+        """Return MSE (i.e. L2-norm) distance between vector for word `a` and
+        vector for word `b`.
+
+        Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
+        Args:
+            a (Union[str|int]): Either word or integer presenting the id of the word
+            b (Union[str|int]): Either word or integer presenting the id of the word
+        Returns:
+            distance (float): MSE (L2) distance
+        """
+        if isinstance(a, str):
+            a = self._word2index[a]
+        if isinstance(b, str):
+            b = self._word2index[b]
+        a, b = min(a, b), max(a, b)
+        try:
+            mse_dist = self._mse_dist_mat[a][b]
+        except KeyError:
+            e1 = self.embedding_matrix[a]
+            e2 = self.embedding_matrix[b]
+            e1 = torch.tensor(e1).to(utils.device)
+            e2 = torch.tensor(e2).to(utils.device)
+            mse_dist = torch.sum((e1 - e2) ** 2).item()
+            self._mse_dist_mat[a][b] = mse_dist
+
+        return mse_dist
+
+    def get_cos_sim(self, a, b):
+        """Return cosine similarity between vector for word `a` and vector for
+        word `b`.
+
+        Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
+        Args:
+            a (Union[str|int]): Either word or integer presenting the id of the word
+            b (Union[str|int]): Either word or integer presenting the id of the word
+        Returns:
+            distance (float): cosine similarity
+        """
+        if isinstance(a, str):
+            a = self._word2index[a]
+        if isinstance(b, str):
+            b = self._word2index[b]
+        a, b = min(a, b), max(a, b)
+        try:
+            cos_sim = self._cos_sim_mat[a][b]
+        except KeyError:
+            e1 = self.embedding_matrix[a]
+            e2 = self.embedding_matrix[b]
+            e1 = torch.tensor(e1).to(utils.device)
+            e2 = torch.tensor(e2).to(utils.device)
+            cos_sim = torch.nn.CosineSimilarity(dim=0)(e1, e2).item()
+            self._cos_sim_mat[a][b] = cos_sim
+        return cos_sim
+
+    def nearest_neighbours(self, index, topn):
+        """
+        Get top-N nearest neighbours for a word
+        Args:
+            index (int): ID of the word for which we're finding the nearest neighbours
+            topn (int): Used for specifying N nearest neighbours
+        Returns:
+            neighbours (list[int]): List of indices of the nearest neighbours
+        """
+        if isinstance(index, str):
+            index = self._word2index[index]
+        if self.nn_matrix is not None:
+            nn = self.nn_matrix[index][1 : (topn + 1)]
         else:
-            raise ValueError(f"Could not find word embedding {embedding_type}")
+            try:
+                nn = self._nn_cache[index]
+            except KeyError:
+                embedding = torch.tensor(self.embedding_matrix).to(utils.device)
+                vector = torch.tensor(self.embedding_matrix[index]).to(utils.device)
+                dist = torch.norm(embedding - vector, dim=1, p=None)
+                # Since closest neighbour will be the same word, we consider N+1 nearest neighbours
+                nn = dist.topk(topn + 1, largest=False)[1:].tolist()
+                self._nn_cache[index] = nn
+
+        return nn
+
+    @staticmethod
+    def counterfitted_GLOVE_embedding():
+        """Returns a prebuilt counter-fitted GLOVE word embedding proposed by
+        "Counter-fitting Word Vectors to Linguistic Constraints" (Mrkšić et
+        al., 2016)"""
+        word_embeddings_folder = "paragramcf"
+        word_embeddings_file = "paragram.npy"
+        word_list_file = "wordlist.pickle"
+        mse_dist_file = "mse_dist.p"
+        cos_sim_file = "cos_sim.p"
+        nn_matrix_file = "nn.npy"
 
         # Download embeddings if they're not cached.
         word_embeddings_folder = os.path.join(
-            WordEmbedding.PATH, word_embeddings_folder
+            TextAttackWordEmbedding.PATH, word_embeddings_folder
         )
-        word_embeddings_folder = textattack.shared.utils.download_if_needed(
-            word_embeddings_folder
-        )
-
+        word_embeddings_folder = utils.download_if_needed(word_embeddings_folder)
         # Concatenate folder names to create full path to files.
         word_embeddings_file = os.path.join(
             word_embeddings_folder, word_embeddings_file
@@ -91,234 +275,152 @@ class WordEmbedding:
         nn_matrix_file = os.path.join(word_embeddings_folder, nn_matrix_file)
 
         # loading the files
-        self._embeddings = np.load(word_embeddings_file)
-        self._word2index = np.load(word_list_file, allow_pickle=True)
-        if os.path.exists(mse_dist_file):
-            with open(mse_dist_file, "rb") as f:
-                self._mse_dist_mat = pickle.load(f)
-        else:
-            self._mse_dist_mat = defaultdict(dict)
-        if os.path.exists(cos_sim_file):
-            with open(cos_sim_file, "rb") as f:
-                self._cos_sim_mat = pickle.load(f)
-        else:
-            self._cos_sim_mat = defaultdict(dict)
+        embedding_matrix = np.load(word_embeddings_file)
+        word2index = np.load(word_list_file, allow_pickle=True)
+        index2word = {}
+        for word, index in word2index.items():
+            index2word[index] = word
+        nn_matrix = np.load(nn_matrix_file)
 
-        self._nn = np.load(nn_matrix_file)
+        word_embedding = TextAttackWordEmbedding(
+            embedding_matrix, word2index, index2word, nn_matrix
+        )
+        with open(mse_dist_file, "rb") as f:
+            mse_dist_mat = pickle.load(f)
+        with open(cos_sim_file, "rb") as f:
+            cos_sim_mat = pickle.load(f)
 
-        # Build glove dict and index.
-        self._index2word = dict()
-        for word, index in self._word2index.items():
-            self._index2word[index] = word
+        word_embedding._mse_dist_mat = mse_dist_mat
+        word_embedding._cos_sim_mat = cos_sim_mat
 
-    def _init_embeddings_from_gensim(self, embedding_type):
-        """
-        Initialize word embedding from a gensim word2vec model
-        Args:
-            embedding_type:
+        return word_embedding
 
-        Returns:
 
-        """
-        import gensim
+class GensimWordEmbedding(WordEmbedding):
+    """Wraps Gensim's KeyedVectors
+    (https://radimrehurek.com/gensim/models/keyedvectors.html)"""
 
-        if embedding_type.endswith(".bin"):
-            self._gensim_keyed_vectors = (
-                gensim.models.KeyedVectors.load_word2vec_format(
-                    embedding_type, binary=True
+    def __init__(self, keyed_vectors_or_path):
+        gensim = utils.LazyLoader("gensim", globals(), "gensim")
+
+        if isinstance(keyed_vectors_or_path, str):
+            if keyed_vectors_or_path.endswith(".bin"):
+                self.keyed_vectors = gensim.models.KeyedVectors.load_word2vec_format(
+                    keyed_vectors_or_path, binary=True
                 )
-            )
+            else:
+                self.keyed_vectors = gensim.models.KeyedVectors.load_word2vec_format(
+                    keyed_vectors_or_path
+                )
+        elif isinstance(keyed_vectors_or_path, gensim.models.KeyedVectors):
+            self.keyed_vectors = keyed_vectors_or_path
         else:
-            self._gensim_keyed_vectors = (
-                gensim.models.KeyedVectors.load_word2vec_format(embedding_type)
+            raise ValueError(
+                "`keyed_vectors_or_path` argument must either be `gensim.models.KeyedVectors` object "
+                "or a path pointing to the saved KeyedVector object"
             )
-        self._gensim_keyed_vectors.init_sims()
 
-    def _init_embeddings_from_type(self, embedding_source, embedding_type):
-        """Initializes embedding based on the source.
-
-        Downloads and loads embeddings into memory.
-        """
-
-        if embedding_source == "defaults":
-            self._init_embeddings_from_defaults(embedding_type)
-        elif embedding_source == "gensim":
-            self._init_embeddings_from_gensim(embedding_type)
-        else:
-            raise ValueError(f"Not supported word embedding source {embedding_source}")
+        self.keyed_vectors.init_sims()
+        self._mse_dist_mat = defaultdict(dict)
+        self._cos_sim_mat = defaultdict(dict)
 
     def __getitem__(self, index):
-        """Gets a word embedding by word or ID.
-
-        If word or ID not found, returns None.
-        """
-        if self.embedding_source == "defaults":
-            if isinstance(index, str):
-                try:
-                    index = self._word2index[index]
-                except KeyError:
-                    return None
-            try:
-                return self._embeddings[index]
-            except IndexError:
-                # word embedding ID out of bounds
-                return None
-        elif self.embedding_source == "gensim":
-            if isinstance(index, str):
-                try:
-                    index = self._gensim_keyed_vectors.vocab.get(index).index
-                except KeyError:
-                    return None
-            try:
-                return self._gensim_keyed_vectors.vectors_norm[index]
-            except IndexError:
-                # word embedding ID out of bounds
-                return None
-        else:
-            raise ValueError(
-                f"Not supported word embedding source {self.embedding_source}"
-            )
-
-    def get_cos_sim(self, a, b):
-        """
-        get cosine similarity of two words/IDs
+        """Gets the embedding vector for word/id
         Args:
-            a:
-            b:
-
+            index (Union[str|int]): `index` can either be word or integer representing the id of the word.
         Returns:
+            vector (ndarray): 1-D embedding vector. If corresponding vector cannot be found for `index`, returns `None`.
+        """
+        if isinstance(index, str):
+            try:
+                index = self.keyed_vectors.vocab.get(index).index
+            except KeyError:
+                return None
+        try:
+            return self.keyed_vectors.vectors_norm[index]
+        except IndexError:
+            # word embedding ID out of bounds
+            return None
+
+    def word2index(self, word):
+        """
+        Convert between word to id (i.e. index of word in embedding matrix)
+        Args:
+            word (str)
+        Returns:
+            index (int)
+        """
+        vocab = self.keyed_vectors.vocab.get(word)
+        if vocab is None:
+            raise KeyError(word)
+        return vocab.index
+
+    def index2word(self, index):
+        """
+        Convert index to corresponding word
+        Args:
+            index (int)
+        Returns:
+            word (str)
 
         """
-        if self.embedding_source == "defaults":
-            if isinstance(a, str):
-                a = self._word2index[a]
-            if isinstance(b, str):
-                b = self._word2index[b]
-            a, b = min(a, b), max(a, b)
-            try:
-                cos_sim = self._cos_sim_mat[a][b]
-            except KeyError:
-                e1 = self._embeddings[a]
-                e2 = self._embeddings[b]
-                e1 = torch.tensor(e1).to(utils.device)
-                e2 = torch.tensor(e2).to(utils.device)
-                cos_sim = torch.nn.CosineSimilarity(dim=0)(e1, e2).item()
-                self._cos_sim_mat[a][b] = cos_sim
-            return cos_sim
-        elif self.embedding_source == "gensim":
-            if not isinstance(a, str):
-                a = self._gensim_keyed_vectors.index2word[a]
-            if not isinstance(b, str):
-                b = self._gensim_keyed_vectors.index2word[b]
-            cos_sim = self._gensim_keyed_vectors.similarity(a, b)
-            return cos_sim
-        else:
-            raise ValueError(
-                f"Not supported word embedding source {self.embedding_source}"
-            )
+        try:
+            # this is a list, so the error would be IndexError
+            return self.keyed_vectors.index2word[index]
+        except IndexError:
+            raise KeyError(index)
 
     def get_mse_dist(self, a, b):
-        """
-        get mse distance of two IDs
+        """Return MSE (i.e. L2-norm) distance between vector for word `a` and
+        vector for word `b`.
+
+        Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
         Args:
-            a:
-            b:
-
+            a (Union[str|int]): Either word or integer presenting the id of the word
+            b (Union[str|int]): Either word or integer presenting the id of the word
         Returns:
-
+            distance (float): MSE (L2) distance
         """
-        if self.embedding_source == "defaults":
-            a, b = min(a, b), max(a, b)
-            try:
-                mse_dist = self._mse_dist_mat[a][b]
-            except KeyError:
-                e1 = self._embeddings[a]
-                e2 = self._embeddings[b]
-                e1 = torch.tensor(e1).to(utils.device)
-                e2 = torch.tensor(e2).to(utils.device)
-                mse_dist = torch.sum((e1 - e2) ** 2).item()
-                self._mse_dist_mat[a][b] = mse_dist
-            return mse_dist
-        elif self.embedding_source == "gensim":
-            if self._mse_dist_mat is None:
-                self._mse_dist_mat = defaultdict(dict)
-            try:
-                mse_dist = self._mse_dist_mat[a][b]
-            except KeyError:
-                e1 = self._gensim_keyed_vectors.vectors_norm[a]
-                e2 = self._gensim_keyed_vectors.vectors_norm[b]
-                e1 = torch.tensor(e1).to(utils.device)
-                e2 = torch.tensor(e2).to(utils.device)
-                mse_dist = torch.sum((e1 - e2) ** 2).item()
-                self._mse_dist_mat[a][b] = mse_dist
-            return mse_dist
-        else:
-            raise ValueError(
-                f"Not supported word embedding source {self.embedding_source}"
-            )
+        try:
+            mse_dist = self._mse_dist_mat[a][b]
+        except KeyError:
+            e1 = self.keyed_vectors.vectors_norm[a]
+            e2 = self.keyed_vectors.vectors_norm[b]
+            e1 = torch.tensor(e1).to(utils.device)
+            e2 = torch.tensor(e2).to(utils.device)
+            mse_dist = torch.sum((e1 - e2) ** 2).item()
+            self._mse_dist_mat[a][b] = mse_dist
+        return mse_dist
 
-    def word2ind(self, word):
-        """
-        word to index
+    def get_cos_sim(self, a, b):
+        """Return cosine similarity between vector for word `a` and vector for
+        word `b`.
+
+        Since this is a metric, `get_mse_dist(a,b)` and `get_mse_dist(b,a)` should return the same value.
         Args:
-            word:
-
+            a (Union[str|int]): Either word or integer presenting the id of the word
+            b (Union[str|int]): Either word or integer presenting the id of the word
         Returns:
-
+            distance (float): cosine similarity
         """
-        if self.embedding_source == "defaults":
-            return self._word2index[word]
-        elif self.embedding_source == "gensim":
-            vocab = self._gensim_keyed_vectors.vocab.get(word)
-            if vocab is None:
-                raise KeyError(word)
-            return vocab.index
-        else:
-            raise ValueError(
-                f"Not supported word embedding source {self.embedding_source}"
-            )
+        if not isinstance(a, str):
+            a = self.keyed_vectors.index2word[a]
+        if not isinstance(b, str):
+            b = self.keyed_vectors.index2word[b]
+        cos_sim = self.keyed_vectors.similarity(a, b)
+        return cos_sim
 
-    def ind2word(self, index):
+    def nearest_neighbours(self, index, topn, return_words=True):
         """
-        index to word
+        Get top-N nearest neighbours for a word
         Args:
-            index:
-
+            index (int): ID of the word for which we're finding the nearest neighbours
+            topn (int): Used for specifying N nearest neighbours
         Returns:
-
+            neighbours (list[int]): List of indices of the nearest neighbours
         """
-        if self.embedding_source == "defaults":
-            return self._index2word[index]
-        elif self.embedding_source == "gensim":
-            try:
-                # this is a list, so the error would be IndexError
-                return self._gensim_keyed_vectors.index2word[index]
-            except IndexError:
-                raise KeyError(index)
-        else:
-            raise ValueError(
-                f"Not supported word embedding source {self.embedding_source}"
-            )
-
-    def nn(self, index, topn):
-        """
-        get top n nearest neighbours for a word
-        Args:
-            index:
-            topn:
-
-        Returns:
-
-        """
-        if self.embedding_source == "defaults":
-            return self._nn[index][1 : (topn + 1)]
-        elif self.embedding_source == "gensim":
-            word = self._gensim_keyed_vectors.index2word[index]
-            return [
-                self._gensim_keyed_vectors.index2word.index(i[0])
-                for i in self._gensim_keyed_vectors.similar_by_word(word, topn)
-            ]
-        else:
-            raise ValueError(
-                f"Not supported word embedding source {self.embedding_source}"
-            )
+        word = self.keyed_vectors.index2word[index]
+        return [
+            self.keyed_vectors.index2word.index(i[0])
+            for i in self.keyed_vectors.similar_by_word(word, topn)
+        ]

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -14,15 +14,15 @@ import torch
 from textattack.shared import utils
 
 
-class WordEmbedding(ABC):
+class AbstractWordEmbedding(ABC):
     """Abstract class representing word embedding used by TextAttack.
 
     This class specifies all the methods that is required to be defined
     so that it can be used for transformation and constraints. For
     custom word embedding not supported by TextAttack, please create a
     class that inherits this class and implement the required methods.
-    However, please first check if you can use `TextAttackWordEmbedding`
-    class, which has a lot of internal methods implemented.
+    However, please first check if you can use `WordEmbedding` class,
+    which has a lot of internal methods implemented.
     """
 
     @abstractmethod
@@ -100,7 +100,7 @@ class WordEmbedding(ABC):
     __repr__ = __str__ = utils.default_class_repr
 
 
-class TextAttackWordEmbedding(WordEmbedding):
+class WordEmbedding(AbstractWordEmbedding):
     """Object for loading word embeddings and related distances for TextAttack.
     This class has a lot of internal components (e.g. get consine similarity)
     implemented. Consider using this class if you can provide the appropriate
@@ -257,7 +257,7 @@ class TextAttackWordEmbedding(WordEmbedding):
             "textattack_counterfitted_GLOVE_embedding" in utils.GLOBAL_OBJECTS
             and isinstance(
                 utils.GLOBAL_OBJECTS["textattack_counterfitted_GLOVE_embedding"],
-                TextAttackWordEmbedding,
+                WordEmbedding,
             )
         ):
             # avoid recreating same embedding (same memory) and instead share across different components
@@ -272,7 +272,7 @@ class TextAttackWordEmbedding(WordEmbedding):
 
         # Download embeddings if they're not cached.
         word_embeddings_folder = os.path.join(
-            TextAttackWordEmbedding.PATH, word_embeddings_folder
+            WordEmbedding.PATH, word_embeddings_folder
         )
         word_embeddings_folder = utils.download_if_needed(word_embeddings_folder)
         # Concatenate folder names to create full path to files.
@@ -292,9 +292,7 @@ class TextAttackWordEmbedding(WordEmbedding):
             index2word[index] = word
         nn_matrix = np.load(nn_matrix_file)
 
-        embedding = TextAttackWordEmbedding(
-            embedding_matrix, word2index, index2word, nn_matrix
-        )
+        embedding = WordEmbedding(embedding_matrix, word2index, index2word, nn_matrix)
 
         with open(mse_dist_file, "rb") as f:
             mse_dist_mat = pickle.load(f)
@@ -309,7 +307,7 @@ class TextAttackWordEmbedding(WordEmbedding):
         return embedding
 
 
-class GensimWordEmbedding(WordEmbedding):
+class GensimWordEmbedding(AbstractWordEmbedding):
     """Wraps Gensim's `KeyedVectors`
     (https://radimrehurek.com/gensim/models/keyedvectors.html)"""
 

--- a/textattack/transformations/word_swap_embedding.py
+++ b/textattack/transformations/word_swap_embedding.py
@@ -3,7 +3,7 @@ Word Swap by Embedding
 ============================================
 
 """
-from textattack.shared import TextAttackWordEmbedding, WordEmbedding
+from textattack.shared import AbstractWordEmbedding, WordEmbedding
 from textattack.transformations.word_swap import WordSwap
 
 
@@ -13,20 +13,20 @@ class WordSwapEmbedding(WordSwap):
 
     Args:
         max_candidates (int): maximum number of synonyms to pick
-        embedding (textattack.shared.WordEmbedding): Wrapper for word embedding
+        embedding (textattack.shared.AbstractWordEmbedding): Wrapper for word embedding
     """
 
     def __init__(
         self,
         max_candidates=15,
-        embedding=TextAttackWordEmbedding.counterfitted_GLOVE_embedding(),
+        embedding=WordEmbedding.counterfitted_GLOVE_embedding(),
         **kwargs
     ):
         super().__init__(**kwargs)
         self.max_candidates = max_candidates
-        if not isinstance(embedding, WordEmbedding):
+        if not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
-                "`embedding` object must be of type `textattack.shared.WordEmbedding`."
+                "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."
             )
         self.embedding = embedding
 


### PR DESCRIPTION
1. extended the WordEmbedding class to implement 2 ways to initialize a word embedding: one is as before downloading from s3 all the files needed(embeddingmat, cos_sim_mat, etc..); the other being using gensim keyedvector to avoid re-implementing things(example in test case) 
2. incorporated WordEmbeddings with WordSwapEmbedding and WordEmbeddingDistance and ThoughtVector as per https://github.com/QData/TextAttack/issues/325#issuecomment-724888184. APIs of these 3 class are unchanged except an additional argument in __init__ to indicate whether to use embeddings from textattack s3 or in gensim keyedvectors format.
