### PR TITLE
fix inflection generation and enlarge pos to upos mapping (for Morpheus)

### DIFF
--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -29,16 +29,16 @@ class WordSwapInflections(WordSwap):
         super().__init__(**kwargs)
         # fine-grained en-ptb POS to universal POS mapping
         # (mapping info: https://github.com/slavpetrov/universal-pos-tags)
-        self._enptb_to_universal = {'JJRJR': 'ADJ', 'VBN': 'VERB', 'NN': 'NOUN', 'VBG': 'NOUN',
-                                  'VBP': 'VERB', 'JJ': 'ADJ', 'VBZ': 'VERB',
-                                  'VBG': 'VERB', 'NN': 'NOUN', 'VBD': 'VERB',
-                                  'NP': 'NOUN', 'NNS': 'NOUN', 'NNP': 'NOUN',
-                                  'JJ': 'ADJ', 'VBG': 'ADJ', 'VB': 'VERB', 'NN': 'NOUN',
-                                  'NNS': 'NOUN', 'VP': 'VERB', 'TO': 'VERB',
-                                  'VBP': 'VERB', 'NN': 'NOUN', 'SYM': 'NOUN',
-                                  'VBG': 'VERB', 'NN': 'VERB', 'MD': 'VERB',
-                                  'NNPS': 'NOUN', 'VBD': 'VERB', 'VBN': 'VERB',
-                                  'JJS': 'ADJ', 'JJR': 'ADJ', 'JJ': 'ADJ', 'RB': 'ADJ'}
+        self._enptb_to_universal = {'JJRJR': 'ADJ', 'VBN': 'VERB',
+                                    'VBP': 'VERB', 'JJ': 'ADJ',
+                                    'VBZ': 'VERB', 'VBG': 'VERB',
+                                    'NN': 'NOUN', 'VBD': 'VERB',
+                                    'NP': 'NOUN', 'NNP': 'NOUN',
+                                    'VB': 'VERB', 'NNS': 'NOUN',
+                                    'VP': 'VERB', 'TO': 'VERB',
+                                    'SYM': 'NOUN', 'MD': 'VERB',
+                                    'NNPS': 'NOUN', 'JJS': 'ADJ',
+                                    'JJR': 'ADJ', 'RB': 'ADJ'}
 
     def _get_replacement_words(self, word, word_part_of_speech):
         # only nouns, verbs, and adjectives are considered for replacement

--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -6,9 +6,9 @@ Word Swap by inflections
 """
 
 
-import lemminflect
 import random
 
+import lemminflect
 from textattack.transformations.word_swap import WordSwap
 
 

--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -7,6 +7,7 @@ Word Swap by inflections
 
 
 import lemminflect
+import random
 
 from textattack.transformations.word_swap import WordSwap
 
@@ -26,25 +27,51 @@ class WordSwapInflections(WordSwap):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self._flair_to_lemminflect_pos_map = {"NN": "NOUN", "VB": "VERB", "JJ": "ADJ"}
+        # fine-grained en-ptb POS to universal POS mapping
+        # (mapping info: https://github.com/slavpetrov/universal-pos-tags)
+        self._enptb_to_universal = {'JJRJR': 'ADJ', 'VBN': 'VERB', 'NN': 'NOUN', 'VBG': 'NOUN',
+                                  'VBP': 'VERB', 'JJ': 'ADJ', 'VBZ': 'VERB',
+                                  'VBG': 'VERB', 'NN': 'NOUN', 'VBD': 'VERB',
+                                  'NP': 'NOUN', 'NNS': 'NOUN', 'NNP': 'NOUN',
+                                  'JJ': 'ADJ', 'VBG': 'ADJ', 'VB': 'VERB', 'NN': 'NOUN',
+                                  'NNS': 'NOUN', 'VP': 'VERB', 'TO': 'VERB',
+                                  'VBP': 'VERB', 'NN': 'NOUN', 'SYM': 'NOUN',
+                                  'VBG': 'VERB', 'NN': 'VERB', 'MD': 'VERB',
+                                  'NNPS': 'NOUN', 'VBD': 'VERB', 'VBN': 'VERB',
+                                  'JJS': 'ADJ', 'JJR': 'ADJ', 'JJ': 'ADJ', 'RB': 'ADJ'}
 
     def _get_replacement_words(self, word, word_part_of_speech):
-
-        if word_part_of_speech not in self._flair_to_lemminflect_pos_map:
-            # Only nouns, verbs, and adjectives have proper inflections.
+        # only nouns, verbs, and adjectives are considered for replacement
+        if word_part_of_speech not in self._enptb_to_universal:
             return []
+
+        # gets a dict that maps part-of-speech (POS) to available lemmas
         replacement_inflections_dict = lemminflect.getAllLemmas(word)
-        # `lemminflect.getAllLemmas` returns a dict mapping part-of-speech
-        # to available inflections. First, map part-of-speech from flair
-        # POS tag to lemminflect.
-        lemminflect_pos = self._flair_to_lemminflect_pos_map[word_part_of_speech]
-        replacement_words = replacement_inflections_dict.get(lemminflect_pos, list())
+
+        # if dict is empty, there are no replacements for this word
+        if not replacement_inflections_dict:
+            return []
+
+        # map the fine-grained POS to a universal POS
+        lemminflect_pos = self._enptb_to_universal[word_part_of_speech]
+
+        # choose lemma with same POS, if ones exists; otherwise, choose lemma randomly
+        if lemminflect_pos in replacement_inflections_dict:
+            lemma = replacement_inflections_dict[lemminflect_pos][0]
+        else:
+            lemma = random.choice(list(replacement_inflections_dict.values()))[0]
+
+        # get the available inflections for chosen lemma
+        inflections = lemminflect.getAllInflections(lemma, upos=lemminflect_pos).values()
+
+        # merge tuples, remove duplicates, remove copy of the original word
+        replacement_words = list(set([infl for tup in inflections for infl in tup]))
         replacement_words = [r for r in replacement_words if r != word]
+
         return replacement_words
 
     def _get_transformations(self, current_text, indices_to_modify):
         transformed_texts = []
-
         for i in indices_to_modify:
             word_to_replace = current_text.words[i]
             word_to_replace_pos = current_text.pos_of_word_index(i)

--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -22,23 +22,34 @@ class WordSwapInflections(WordSwap):
     `Paper URL`_
 
     .. _Paper URL: https://www.aclweb.org/anthology/2020.acl-main.263.pdf
-
     """
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         # fine-grained en-ptb POS to universal POS mapping
         # (mapping info: https://github.com/slavpetrov/universal-pos-tags)
-        self._enptb_to_universal = {'JJRJR': 'ADJ', 'VBN': 'VERB',
-                                    'VBP': 'VERB', 'JJ': 'ADJ',
-                                    'VBZ': 'VERB', 'VBG': 'VERB',
-                                    'NN': 'NOUN', 'VBD': 'VERB',
-                                    'NP': 'NOUN', 'NNP': 'NOUN',
-                                    'VB': 'VERB', 'NNS': 'NOUN',
-                                    'VP': 'VERB', 'TO': 'VERB',
-                                    'SYM': 'NOUN', 'MD': 'VERB',
-                                    'NNPS': 'NOUN', 'JJS': 'ADJ',
-                                    'JJR': 'ADJ', 'RB': 'ADJ'}
+        self._enptb_to_universal = {
+            "JJRJR": "ADJ",
+            "VBN": "VERB",
+            "VBP": "VERB",
+            "JJ": "ADJ",
+            "VBZ": "VERB",
+            "VBG": "VERB",
+            "NN": "NOUN",
+            "VBD": "VERB",
+            "NP": "NOUN",
+            "NNP": "NOUN",
+            "VB": "VERB",
+            "NNS": "NOUN",
+            "VP": "VERB",
+            "TO": "VERB",
+            "SYM": "NOUN",
+            "MD": "VERB",
+            "NNPS": "NOUN",
+            "JJS": "ADJ",
+            "JJR": "ADJ",
+            "RB": "ADJ",
+        }
 
     def _get_replacement_words(self, word, word_part_of_speech):
         # only nouns, verbs, and adjectives are considered for replacement
@@ -62,7 +73,9 @@ class WordSwapInflections(WordSwap):
             lemma = random.choice(list(replacement_inflections_dict.values()))[0]
 
         # get the available inflections for chosen lemma
-        inflections = lemminflect.getAllInflections(lemma, upos=lemminflect_pos).values()
+        inflections = lemminflect.getAllInflections(
+            lemma, upos=lemminflect_pos
+        ).values()
 
         # merge tuples, remove duplicates, remove copy of the original word
         replacement_words = list(set([infl for tup in inflections for infl in tup]))

--- a/textattack/transformations/word_swap_inflections.py
+++ b/textattack/transformations/word_swap_inflections.py
@@ -9,6 +9,7 @@ Word Swap by inflections
 import random
 
 import lemminflect
+
 from textattack.transformations.word_swap import WordSwap
 
 


### PR DESCRIPTION
I think `textattack/transformations/word_swap_inflections.py` had a couple issues. [These are issues in the sense that the Morpheus attack&ndash;that relies on this transformation&ndash;is not a correct copy of the authors' original implementation of Morpheus when it uses this transformation.]
Specifically:
**1.** The function `_get_replacement_words` wasn't returning the correct lists of inflections. For example, notice that
```
>>> lemminflect.getAllLemmas('is')
{'AUX': ('be',), 'VERB': ('be',)}
```

However, according to the Morpheus paper, we want not only 'be', but 'been', 'am', 'was', 'are', 'were', and 'being'. To get this full list, you must take one of the lemmas returned by `lemminflect.getAllLemmas` (in this case, 'be') and get its inflections: 

```
>>> lemminflect.getAllInflections('be', upos='VERB').values()
dict_values([('be',), ('was', 'were'), ('being',), ('been',), ('am', 'are'), ('is',)])
```
**2.** The number of considered POS tags was too low. The result was that many words that had inflections were being skipped over and not considered for replacement. Therefore, I expanded the mapping using the en-ptb (English Penn Treebank) POS to universal POS mapping introduced [here](https://github.com/slavpetrov/universal-pos-tags/blob/master/en-ptb.map).

