### PR TITLE
fix model query count when no candidate result scores are improvements over current result score

### DIFF
--- a/tests/sample_outputs/run_attack_faster_alzantot_recipe.txt
+++ b/tests/sample_outputs/run_attack_faster_alzantot_recipe.txt
@@ -56,16 +56,16 @@ hugh grant , who has a good line in charm , has never been more [91mloveable[0
 
 
 
-+-------------------------------+--------+
-| Attack Results                |        |
-+-------------------------------+--------+
-| Number of successful attacks: | 2      |
-| Number of failed attacks:     | 1      |
-| Number of skipped attacks:    | 0      |
-| Original accuracy:            | 100.0% |
-| Accuracy under attack:        | 33.33% |
-| Attack success rate:          | 66.67% |
-| Average perturbed word %:     | 17.34% |
-| Average num. words per input: | 15.0   |
-| Avg num queries:              | 551.67 |
-+-------------------------------+--------+
++-------------------------------+---------+
+| Attack Results                |         |
++-------------------------------+---------+
+| Number of successful attacks: | 2       |
+| Number of failed attacks:     | 1       |
+| Number of skipped attacks:    | 0       |
+| Original accuracy:            | 100.0%  |
+| Accuracy under attack:        | 33.33%  |
+| Attack success rate:          | 66.67%  |
+| Average perturbed word %:     | 17.34%  |
+| Average num. words per input: | 15.0    |
+| Avg num queries:              | 1132.67 |
++-------------------------------+---------+

--- a/textattack/search_methods/genetic_algorithm.py
+++ b/textattack/search_methods/genetic_algorithm.py
@@ -101,9 +101,6 @@ class GeneticAlgorithm(PopulationBasedSearch, ABC):
 
             new_results, self._search_over = self.get_goal_results(transformed_texts)
 
-            if self._search_over:
-                break
-
             diff_scores = (
                 torch.Tensor([r.score for r in new_results]) - pop_member.result.score
             )
@@ -119,6 +116,10 @@ class GeneticAlgorithm(PopulationBasedSearch, ABC):
 
             word_select_prob_weights[idx] = 0
             iterations += 1
+
+            if self._search_over:
+                break
+
         return pop_member
 
     @abstractmethod

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -136,6 +136,7 @@ class GreedyWordSwapWIR(SearchMethod):
             if results[0].score > cur_result.score:
                 cur_result = results[0]
             else:
+                cur_result.num_queries = results[0].num_queries
                 continue
             # If we succeeded, return the index with best similarity.
             if cur_result.goal_status == GoalFunctionResultStatus.SUCCEEDED:

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -136,7 +136,6 @@ class GreedyWordSwapWIR(SearchMethod):
             if results[0].score > cur_result.score:
                 cur_result = results[0]
             else:
-                cur_result.num_queries = results[0].num_queries
                 continue
             # If we succeeded, return the index with best similarity.
             if cur_result.goal_status == GoalFunctionResultStatus.SUCCEEDED:

--- a/textattack/search_methods/search_method.py
+++ b/textattack/search_methods/search_method.py
@@ -37,8 +37,10 @@ class SearchMethod(ABC):
             raise AttributeError(
                 "Search Method must have access to get_model method if it is a white-box method"
             )
-
-        return self._perform_search(initial_result)
+        result = self._perform_search(initial_result)
+        # ensure that the number of queries for this GoalFunctionResult is up-to-date
+        result.num_queries = self.goal_function.num_queries
+        return result
 
     @abstractmethod
     def _perform_search(self, initial_result):

--- a/textattack/shared/attack.py
+++ b/textattack/shared/attack.py
@@ -108,6 +108,8 @@ class Attack:
 
         # Give search method access to functions for getting transformations and evaluating them
         self.search_method.get_transformations = self.get_transformations
+        # Give search method access to self.goal_function for model query count, etc.
+        self.search_method.goal_function = self.goal_function
         # The search method only needs access to the first argument. The second is only used
         # by the attack class when checking whether to skip the sample
         self.search_method.get_goal_results = (


### PR DESCRIPTION
It seems that when none of the items in `results` have a higher score than the `cur_result.score`, the `num_queries` attribute of `cur_result` exits the while loop in the `_perform_search` method with an incorrect value of model queries. I think this fixes the problem.