### PR TITLE
make get_grad normal method

### DIFF
--- a/textattack/models/wrappers/model_wrapper.py
+++ b/textattack/models/wrappers/model_wrapper.py
@@ -15,7 +15,6 @@ class ModelWrapper(ABC):
     def __call__(self, text_list):
         raise NotImplementedError()
 
-    @abstractmethod
     def get_grad(self, text_input):
         """Get gradient of loss with respect to input tokens."""
         raise NotImplementedError()


### PR DESCRIPTION
This fixes issue #365 and #354 by not requiring `get_grad` to be defined by child class of `ModelWrapper`