### PR TITLE
fix tag type used by WordSwapHowNet

### DIFF
--- a/textattack/transformations/word_swaps/word_swap_hownet.py
+++ b/textattack/transformations/word_swaps/word_swap_hownet.py
@@ -30,7 +30,7 @@ class WordSwapHowNet(WordSwap):
         with open(cache_path, "rb") as fp:
             self.candidates_bank = pickle.load(fp)
 
-        self.pos_dict = {"JJ": "adj", "NN": "noun", "RB": "adv", "VB": "verb"}
+        self.pos_dict = {"ADJ": "adj", "NOUN": "noun", "ADV": "adv", "VERB": "verb"}
 
     def _get_replacement_words(self, word, word_pos):
         """Returns a list of possible 'candidate words' to replace a word in a


### PR DESCRIPTION
WordSwapHowNet originally used to brown corpus tag set, but we recently switched to universal tag set. This PR reflects the change and fixes issue reported in #374 