### PR TITLE
Clare augmentation recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ for data augmentation:
 - `textattack.CharSwapAugmenter` augments text by substituting, deleting, inserting, and swapping adjacent characters
 - `textattack.EasyDataAugmenter` augments text with a combination of word insertions, substitutions and deletions.
 - `textattack.CheckListAugmenter` augments text by contraction/extension and by substituting names, locations, numbers.
+- `textattack.CLAREAugmenter` augments text by replacing, inserting, and merging with a pre-trained masked language model.
 
 #### Augmentation Command-Line Interface
 The easiest way to use our data augmentation tools is with `textattack augment <args>`. `textattack augment`
@@ -322,6 +323,9 @@ For example, given the following as `examples.csv`:
 The command `textattack augment --csv examples.csv --input-column text --recipe embedding --pct-words-to-swap .1 --transformations-per-example 2 --exclude-original`
 will augment the `text` column by altering 10% of each example's words, generating twice as many augmentations as original inputs, and exclude the original inputs from the
 output CSV. (All of this will be saved to `augment.csv` by default.)
+
+> **Tip:** Just as running attacks interactively, you can also pass `--interactive` to augment samples inputted by the user to quickly try out different augmentation recipes!
+
 
 After augmentation, here are the contents of `augment.csv`:
 ```csv

--- a/tests/sample_outputs/list_augmentation_recipes.txt
+++ b/tests/sample_outputs/list_augmentation_recipes.txt
@@ -1,5 +1,8 @@
 [94mcharswap[0m (textattack.augmentation.CharSwapAugmenter)
 [94mchecklist[0m (textattack.augmentation.CheckListAugmenter)
+[94mwordnet[0m (textattack.augmentation.CLAREAugmenter)
 [94meda[0m (textattack.augmentation.EasyDataAugmenter)
 [94membedding[0m (textattack.augmentation.EmbeddingAugmenter)
 [94mwordnet[0m (textattack.augmentation.WordNetAugmenter)
+
+

--- a/tests/sample_outputs/list_augmentation_recipes.txt
+++ b/tests/sample_outputs/list_augmentation_recipes.txt
@@ -1,8 +1,7 @@
 [94mcharswap[0m (textattack.augmentation.CharSwapAugmenter)
 [94mchecklist[0m (textattack.augmentation.CheckListAugmenter)
-[94mwordnet[0m (textattack.augmentation.CLAREAugmenter)
+[94mclare[0m (textattack.augmentation.CLAREAugmenter)
 [94meda[0m (textattack.augmentation.EasyDataAugmenter)
 [94membedding[0m (textattack.augmentation.EmbeddingAugmenter)
 [94mwordnet[0m (textattack.augmentation.WordNetAugmenter)
-
 

--- a/textattack/augmentation/__init__.py
+++ b/textattack/augmentation/__init__.py
@@ -13,4 +13,6 @@ from .recipes import (
     EasyDataAugmenter,
     CheckListAugmenter,
     DeletionAugmenter,
+    CLAREAugmenter
 )
+

--- a/textattack/augmentation/__init__.py
+++ b/textattack/augmentation/__init__.py
@@ -13,6 +13,5 @@ from .recipes import (
     EasyDataAugmenter,
     CheckListAugmenter,
     DeletionAugmenter,
-    CLAREAugmenter
+    CLAREAugmenter,
 )
-

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -38,9 +38,7 @@ class EasyDataAugmenter(Augmenter):
     """
 
     def __init__(self, pct_words_to_swap=0.1, transformations_per_example=4):
-        assert (
-                0.0 <= pct_words_to_swap <= 1.0
-        ), "pct_words_to_swap must be in [0., 1.]"
+        assert 0.0 <= pct_words_to_swap <= 1.0, "pct_words_to_swap must be in [0., 1.]"
         assert (
             transformations_per_example > 0
         ), "transformations_per_example must be a positive integer"

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -203,9 +203,11 @@ class CLAREAugmenter(Augmenter):
         self, model="distilroberta-base", tokenizer="distilroberta-base", **kwargs
     ):
         import transformers
+
         from textattack.constraints.semantics.sentence_encoders import (
             UniversalSentenceEncoder,
         )
+
         from textattack.transformations import (
             CompositeTransformation,
             WordInsertionMaskedLM,

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -7,6 +7,8 @@ Transformations and constraints can be used for simple NLP data augmentations. H
 """
 import random
 
+from textattack.constraints.semantics.sentence_encoders import UniversalSentenceEncoder
+
 from textattack.constraints.pre_transformation import (
     RepeatModification,
     StopwordModification,
@@ -37,7 +39,7 @@ class EasyDataAugmenter(Augmenter):
 
     def __init__(self, pct_words_to_swap=0.1, transformations_per_example=4):
         assert (
-            pct_words_to_swap >= 0.0 and pct_words_to_swap <= 1.0
+                0.0 <= pct_words_to_swap <= 1.0
         ), "pct_words_to_swap must be in [0., 1.]"
         assert (
             transformations_per_example > 0
@@ -203,10 +205,6 @@ class CLAREAugmenter(Augmenter):
         self, model="distilroberta-base", tokenizer="distilroberta-base", **kwargs
     ):
         import transformers
-
-        from textattack.constraints.semantics.sentence_encoders import (
-            UniversalSentenceEncoder,
-        )
 
         from textattack.transformations import (
             CompositeTransformation,

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -194,11 +194,14 @@ class CLAREAugmenter(Augmenter):
 
     https://arxiv.org/abs/2009.07502
 
-    This method uses greedy search with replace, merge, and insertion transformations that leverage a
-    pretrained language model. It also uses USE similarity constraint.
+    CLARE builds on a pre-trained masked language model and modifies the inputs in a contextaware manner.
+    We propose three contextualized perturbations, Replace, Insert and Merge, allowing for generating outputs
+    of varied lengths.
     """
 
-    def __init__(self, model="distilroberta-base", tokenizer="distilroberta-base", **kwargs):
+    def __init__(
+        self, model="distilroberta-base", tokenizer="distilroberta-base", **kwargs
+    ):
         from textattack.transformations import (
             CompositeTransformation,
             WordInsertionMaskedLM,
@@ -206,7 +209,9 @@ class CLAREAugmenter(Augmenter):
             WordSwapMaskedLM,
         )
         import transformers
-        from textattack.constraints.semantics.sentence_encoders import UniversalSentenceEncoder
+        from textattack.constraints.semantics.sentence_encoders import (
+            UniversalSentenceEncoder,
+        )
 
         shared_masked_lm = transformers.AutoModelForCausalLM.from_pretrained(model)
         shared_tokenizer = transformers.AutoTokenizer.from_pretrained(tokenizer)

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -202,15 +202,15 @@ class CLAREAugmenter(Augmenter):
     def __init__(
         self, model="distilroberta-base", tokenizer="distilroberta-base", **kwargs
     ):
+        import transformers
+        from textattack.constraints.semantics.sentence_encoders import (
+            UniversalSentenceEncoder,
+        )
         from textattack.transformations import (
             CompositeTransformation,
             WordInsertionMaskedLM,
             WordMergeMaskedLM,
             WordSwapMaskedLM,
-        )
-        import transformers
-        from textattack.constraints.semantics.sentence_encoders import (
-            UniversalSentenceEncoder,
         )
 
         shared_masked_lm = transformers.AutoModelForCausalLM.from_pretrained(model)

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -222,19 +222,19 @@ class CLAREAugmenter(Augmenter):
                     method="bae",
                     masked_language_model=shared_masked_lm,
                     tokenizer=shared_tokenizer,
-                    max_candidates=20,
+                    max_candidates=50,
                     min_confidence=5e-4,
                 ),
                 WordInsertionMaskedLM(
                     masked_language_model=shared_masked_lm,
                     tokenizer=shared_tokenizer,
-                    max_candidates=20,
+                    max_candidates=50,
                     min_confidence=0.0,
                 ),
                 WordMergeMaskedLM(
                     masked_language_model=shared_masked_lm,
                     tokenizer=shared_tokenizer,
-                    max_candidates=20,
+                    max_candidates=50,
                     min_confidence=5e-3,
                 ),
             ]

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -7,12 +7,11 @@ Transformations and constraints can be used for simple NLP data augmentations. H
 """
 import random
 
-from textattack.constraints.semantics.sentence_encoders import UniversalSentenceEncoder
-
 from textattack.constraints.pre_transformation import (
     RepeatModification,
     StopwordModification,
 )
+from textattack.constraints.semantics.sentence_encoders import UniversalSentenceEncoder
 
 from . import Augmenter
 

--- a/textattack/commands/augment.py
+++ b/textattack/commands/augment.py
@@ -21,7 +21,7 @@ AUGMENTATION_RECIPE_NAMES = {
     "charswap": "textattack.augmentation.CharSwapAugmenter",
     "eda": "textattack.augmentation.EasyDataAugmenter",
     "checklist": "textattack.augmentation.CheckListAugmenter",
-    "clare": "textattack.augmentation.CLAREAugmenter"
+    "clare": "textattack.augmentation.CLAREAugmenter",
 }
 
 

--- a/textattack/commands/augment.py
+++ b/textattack/commands/augment.py
@@ -21,6 +21,7 @@ AUGMENTATION_RECIPE_NAMES = {
     "charswap": "textattack.augmentation.CharSwapAugmenter",
     "eda": "textattack.augmentation.EasyDataAugmenter",
     "checklist": "textattack.augmentation.CheckListAugmenter",
+    "clare": "textattack.augmentation.CLAREAugmenter"
 }
 
 


### PR DESCRIPTION
This is the augmentation recipe from CLARE, which uses the following transformations:

- WordSwapMaskedLM
- WordInsertionMaskedLM
- WordMergeMaskedLM

The default model and tokenizer are both `distilroberta-base`. Specific models/tokenizers can be specified by the user if they decide to call `CLAREAugmenter` in python. 