### PR TITLE
Fix Bug in Masked LM Transformations

### DIFF
--- a/textattack/transformations/word_insertions/word_insertion_masked_lm.py
+++ b/textattack/transformations/word_insertions/word_insertion_masked_lm.py
@@ -127,7 +127,7 @@ class WordInsertionMaskedLM(WordInsertion):
                             and utils.is_one_word(word)
                             and not utils.check_if_punctuations(word)
                         ):
-                            top_words.append(token)
+                            top_words.append(word)
 
                     if (
                         len(top_words) >= self.max_candidates

--- a/textattack/transformations/word_insertions/word_insertion_masked_lm.py
+++ b/textattack/transformations/word_insertions/word_insertion_masked_lm.py
@@ -109,7 +109,7 @@ class WordInsertionMaskedLM(WordInsertion):
 
                 mask_token_logits = preds[j, masked_index]
                 mask_token_probs = torch.softmax(mask_token_logits, dim=0)
-                ranked_indices = torch.argsort(mask_token_probs)
+                ranked_indices = torch.argsort(mask_token_probs, descending=True)
                 top_words = []
                 for _id in ranked_indices:
                     _id = _id.item()

--- a/textattack/transformations/word_merges/word_merge_masked_lm.py
+++ b/textattack/transformations/word_merges/word_merge_masked_lm.py
@@ -126,7 +126,7 @@ class WordMergeMaskedLM(Transformation):
                             and utils.is_one_word(word)
                             and not utils.check_if_punctuations(word)
                         ):
-                            top_words.append(token)
+                            top_words.append(word)
 
                     if (
                         len(top_words) >= self.max_candidates

--- a/textattack/transformations/word_merges/word_merge_masked_lm.py
+++ b/textattack/transformations/word_merges/word_merge_masked_lm.py
@@ -108,7 +108,7 @@ class WordMergeMaskedLM(Transformation):
 
                 mask_token_logits = preds[j, masked_index]
                 mask_token_probs = torch.softmax(mask_token_logits, dim=0)
-                ranked_indices = torch.argsort(mask_token_probs)
+                ranked_indices = torch.argsort(mask_token_probs, descending=True)
                 top_words = []
                 for _id in ranked_indices:
                     _id = _id.item()

--- a/textattack/transformations/word_swaps/word_swap_masked_lm.py
+++ b/textattack/transformations/word_swaps/word_swap_masked_lm.py
@@ -150,7 +150,7 @@ class WordSwapMaskedLM(WordSwap):
                             and utils.is_one_word(word)
                             and not utils.check_if_punctuations(word)
                         ):
-                            top_words.append(token)
+                            top_words.append(word)
 
                     if (
                         len(top_words) >= self.max_candidates

--- a/textattack/transformations/word_swaps/word_swap_masked_lm.py
+++ b/textattack/transformations/word_swaps/word_swap_masked_lm.py
@@ -132,7 +132,7 @@ class WordSwapMaskedLM(WordSwap):
 
                 mask_token_logits = preds[j, masked_index]
                 mask_token_probs = torch.softmax(mask_token_logits, dim=0)
-                ranked_indices = torch.argsort(mask_token_probs)
+                ranked_indices = torch.argsort(mask_token_probs, descending=True)
                 top_words = []
                 for _id in ranked_indices:
                     _id = _id.item()


### PR DESCRIPTION
# What does this PR do?

## Summary
In `WordSwapMaskedLM`, `WordInsertionMaskedLM`, `WordMergeMasedLM`, we use `torch.argsort` to pick the tokens that have the highest probability. However, `torch.argsort` sorts in ascending order by default, so we need to pass `descending=True` to reverse sort it. Also, it fixes a bug where we replace the words with tokens that have not been sanitized (i.e. you may see "##" appear). 

## Changes
- Pass `descending=True` to `torch.argsort` in `WordSwapMaskedLM`, `WordInsertionMaskedLM`, `WordMergeMasedLM`.
- Sanitize top tokens before adding them to candidate set. 
