### PR TITLE
Added support for FastText word vectors in GensimWordEmbedding class

### DIFF
--- a/tests/test_word_embedding.py
+++ b/tests/test_word_embedding.py
@@ -31,7 +31,9 @@ bye-bye -1 1
     f.close()
 
     gensim = LazyLoader("gensim", globals(), "gensim")
-    keyed_vectors = gensim.models.keyedvectors.Word2VecKeyedVectors.load_word2vec_format(path)
+    keyed_vectors = (
+        gensim.models.keyedvectors.Word2VecKeyedVectors.load_word2vec_format(path)
+    )
     word_embedding = GensimWordEmbedding(keyed_vectors)
     assert pytest.approx(word_embedding[0][0]) == 1
     assert pytest.approx(word_embedding["bye-bye"][0]) == -1 / np.sqrt(2)

--- a/tests/test_word_embedding.py
+++ b/tests/test_word_embedding.py
@@ -15,6 +15,7 @@ def test_embedding_paragramcf():
 
 def test_embedding_gensim():
     # download a trained word2vec model
+    from textattack.shared.utils import LazyLoader
     from textattack.shared.utils.install import TEXTATTACK_CACHE_DIR
 
     path = os.path.join(TEXTATTACK_CACHE_DIR, "test_gensim_embedding.txt")
@@ -28,7 +29,10 @@ bye-bye -1 1
     """
     )
     f.close()
-    word_embedding = GensimWordEmbedding(path)
+
+    gensim = LazyLoader("gensim", globals(), "gensim")
+    keyed_vectors = gensim.models.keyedvectors.Word2VecKeyedVectors.load_word2vec_format(path)
+    word_embedding = GensimWordEmbedding(keyed_vectors)
     assert pytest.approx(word_embedding[0][0]) == 1
     assert pytest.approx(word_embedding["bye-bye"][0]) == -1 / np.sqrt(2)
     assert word_embedding[10 ** 9] is None

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -314,7 +314,9 @@ class GensimWordEmbedding(AbstractWordEmbedding):
     def __init__(self, keyed_vectors):
         gensim = utils.LazyLoader("gensim", globals(), "gensim")
 
-        if isinstance(keyed_vectors, gensim.models.keyedvectors.WordEmbeddingsKeyedVectors):
+        if isinstance(
+            keyed_vectors, gensim.models.keyedvectors.WordEmbeddingsKeyedVectors
+        ):
             self.keyed_vectors = keyed_vectors
         else:
             raise ValueError(

--- a/textattack/shared/word_embedding.py
+++ b/textattack/shared/word_embedding.py
@@ -308,27 +308,18 @@ class WordEmbedding(AbstractWordEmbedding):
 
 
 class GensimWordEmbedding(AbstractWordEmbedding):
-    """Wraps Gensim's `KeyedVectors`
+    """Wraps Gensim's `models.keyedvectors` module
     (https://radimrehurek.com/gensim/models/keyedvectors.html)"""
 
-    def __init__(self, keyed_vectors_or_path):
+    def __init__(self, keyed_vectors):
         gensim = utils.LazyLoader("gensim", globals(), "gensim")
 
-        if isinstance(keyed_vectors_or_path, str):
-            if keyed_vectors_or_path.endswith(".bin"):
-                self.keyed_vectors = gensim.models.KeyedVectors.load_word2vec_format(
-                    keyed_vectors_or_path, binary=True
-                )
-            else:
-                self.keyed_vectors = gensim.models.KeyedVectors.load_word2vec_format(
-                    keyed_vectors_or_path
-                )
-        elif isinstance(keyed_vectors_or_path, gensim.models.KeyedVectors):
-            self.keyed_vectors = keyed_vectors_or_path
+        if isinstance(keyed_vectors, gensim.models.keyedvectors.WordEmbeddingsKeyedVectors):
+            self.keyed_vectors = keyed_vectors
         else:
             raise ValueError(
-                "`keyed_vectors_or_path` argument must either be `gensim.models.KeyedVectors` object "
-                "or a path pointing to the saved KeyedVector object"
+                "`keyed_vectors` argument must be a "
+                "`gensim.models.keyedvectors.WordEmbeddingsKeyedVectors` object"
             )
 
         self.keyed_vectors.init_sims()


### PR DESCRIPTION
# What does this PR do?

## Summary
* This PR adds the possibility to use FastText embeddings for the WordSwapEmbedding augmentation by passing the KeyedVectors (Word2Vec or FastText) to the `__init__` of GensimWordEmbeddings.

## Additions
- Support for FastText word vectors in GensimWordEmbedding class (not only Word2Vec)

## Changes
- GensimWordEmbeddings `__init__` now requires passing pre-loaded WordEmbeddingsKeyedVectors

## Deletions
- GensimWordEmbeddings `__init__` does not support passing the path of a saved word embedding file anymore (due to specific loading logic of different embedding types)

## Checklist
- [ X ] The title of your pull request should be a summary of its contribution.
- [ X ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [ X ] Make sure existing tests pass.
- [ X ] Add relevant tests. No quality testing = no merge.
- [ X ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
