### PR TITLE
fix all_words_diff problem

### DIFF
--- a/docs/1start/FAQ.md
+++ b/docs/1start/FAQ.md
@@ -28,9 +28,18 @@ For help and realtime updates related to TextAttack, please [join the TextAttack
 ## More Concrete Questions: 
 
 
-### 0. For many of the dependent library issues, the following command is the first you should try: 
+### 0. For many of the dependent library issues, the following command is the first you could try: 
 ```bash
 pip install --force-reinstall textattack
+```
+
+Besides, we highly recommend you to use virtual environment for textattack use, 
+see [information here](https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#removing-an-environment). Here is one conda example: 
+
+```bash
+conda create -n textattackenv python=3.7
+conda activate textattackenv
+conda env list
 ```
 
 ### 1. How to Train

--- a/docs/1start/FAQ.md
+++ b/docs/1start/FAQ.md
@@ -28,6 +28,11 @@ For help and realtime updates related to TextAttack, please [join the TextAttack
 ## More Concrete Questions: 
 
 
+### 0. For many of the dependent library issues, the following command is the first you should try: 
+```bash
+pip install --force-reinstall textattack
+```
+
 ### 1. How to Train
 
 For example, you can *Train our default LSTM for 50 epochs on the Yelp Polarity dataset:*

--- a/textattack/loggers/attack_log_manager.py
+++ b/textattack/loggers/attack_log_manager.py
@@ -92,11 +92,11 @@ class AttackLogManager:
             num_words_changed = result.original_result.attacked_text.words_diff_num(
                 result.perturbed_result.attacked_text
             )
-            #num_words_changed = len(
+            # num_words_changed = len(
             #    result.original_result.attacked_text.all_words_diff(
             #        result.perturbed_result.attacked_text
             #    )
-            #)
+            # )
             num_words_changed_until_success[num_words_changed - 1] += 1
             max_words_changed = max(
                 max_words_changed or num_words_changed, num_words_changed

--- a/textattack/loggers/attack_log_manager.py
+++ b/textattack/loggers/attack_log_manager.py
@@ -89,11 +89,14 @@ class AttackLogManager:
                 continue
             else:
                 successful_attacks += 1
-            num_words_changed = len(
-                result.original_result.attacked_text.all_words_diff(
-                    result.perturbed_result.attacked_text
-                )
+            num_words_changed = result.original_result.attacked_text.words_diff_num(
+                result.perturbed_result.attacked_text
             )
+            #num_words_changed = len(
+            #    result.original_result.attacked_text.all_words_diff(
+            #        result.perturbed_result.attacked_text
+            #    )
+            #)
             num_words_changed_until_success[num_words_changed - 1] += 1
             max_words_changed = max(
                 max_words_changed or num_words_changed, num_words_changed

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -250,7 +250,7 @@ class AttackedText:
         if len(w1) - 1 < i or len(w2) - 1 < i:
             return True
         return w1[i] != w2[i]
-    
+
     def words_diff_num(self, other_attacked_text):
         # using edit distance to calculate words diff num
         def generate_tokens(words):
@@ -261,13 +261,17 @@ class AttackedText:
                     result[w] = idx
                     idx += 1
             return result
+
         def words_to_tokens(words, tokens):
             result = []
             for w in words:
                 result.append(tokens[w])
             return result
+
         def edit_distance(w1_t, w2_t):
-            matrix = [[i + j for j in range(len(w2_t) + 1)] for i in range(len(w1_t) + 1)]
+            matrix = [
+                [i + j for j in range(len(w2_t) + 1)] for i in range(len(w1_t) + 1)
+            ]
 
             for i in range(1, len(w1_t) + 1):
                 for j in range(1, len(w2_t) + 1):
@@ -275,18 +279,23 @@ class AttackedText:
                         d = 0
                     else:
                         d = 1
-                    matrix[i][j] = min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + d)
+                    matrix[i][j] = min(
+                        matrix[i - 1][j] + 1,
+                        matrix[i][j - 1] + 1,
+                        matrix[i - 1][j - 1] + d,
+                    )
 
             return matrix[len(w1_t)][len(w2_t)]
+
         def cal_dif(w1, w2):
             tokens = generate_tokens(w1 + w2)
             w1_t = words_to_tokens(w1, tokens)
             w2_t = words_to_tokens(w2, tokens)
             return edit_distance(w1_t, w2_t)
+
         w1 = self.words
         w2 = other_attacked_text.words
         return cal_dif(w1, w2)
-
 
     def convert_from_original_idxs(self, idxs):
         """Takes indices of words from original string and converts them to

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -237,22 +237,9 @@ class AttackedText:
         indices = set()
         w1 = self.words
         w2 = other_attacked_text.words
-        idx1 = 0
-        idx2 = 0
-        flag = False
-        while (idx1 < len(w1) and idx2 < len(w2)):
-            if w1[idx1] == w2[idx2]:
-                flag = False
-                idx1 += 1
-                idx2 += 1
-            elif flag == False:
-                flag = True
-                indices.add(idx1)
-                idx1 += 1
-                idx2 += 1
-            else:
-                flag = False
-                idx2 += 1
+        for i in range(min(len(w1), len(w2))):
+            if w1[i] != w2[i]:
+                indices.add(i)
         return indices
 
     def ith_word_diff(self, other_attacked_text, i):
@@ -263,6 +250,43 @@ class AttackedText:
         if len(w1) - 1 < i or len(w2) - 1 < i:
             return True
         return w1[i] != w2[i]
+    
+    def words_diff_num(self, other_attacked_text):
+        # using edit distance to calculate words diff num
+        def generate_tokens(words):
+            result = {}
+            idx = 1
+            for w in words:
+                if w not in result:
+                    result[w] = idx
+                    idx += 1
+            return result
+        def words_to_tokens(words, tokens):
+            result = []
+            for w in words:
+                result.append(tokens[w])
+            return result
+        def edit_distance(w1_t, w2_t):
+            matrix = [[i + j for j in range(len(w2_t) + 1)] for i in range(len(w1_t) + 1)]
+
+            for i in range(1, len(w1_t) + 1):
+                for j in range(1, len(w2_t) + 1):
+                    if w1_t[i - 1] == w2_t[j - 1]:
+                        d = 0
+                    else:
+                        d = 1
+                    matrix[i][j] = min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + d)
+
+            return matrix[len(w1_t)][len(w2_t)]
+        def cal_dif(w1, w2):
+            tokens = generate_tokens(w1 + w2)
+            w1_t = words_to_tokens(w1, tokens)
+            w2_t = words_to_tokens(w2, tokens)
+            return edit_distance(w1_t, w2_t)
+        w1 = self.words
+        w2 = other_attacked_text.words
+        return cal_dif(w1, w2)
+
 
     def convert_from_original_idxs(self, idxs):
         """Takes indices of words from original string and converts them to

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -237,9 +237,22 @@ class AttackedText:
         indices = set()
         w1 = self.words
         w2 = other_attacked_text.words
-        for i in range(min(len(w1), len(w2))):
-            if w1[i] != w2[i]:
-                indices.add(i)
+        idx1 = 0
+        idx2 = 0
+        flag = False
+        while (idx1 < len(w1) and idx2 < len(w2)):
+            if w1[idx1] == w2[idx2]:
+                flag = False
+                idx1 += 1
+                idx2 += 1
+            elif flag == False:
+                flag = True
+                indices.add(idx1)
+                idx1 += 1
+                idx2 += 1
+            else:
+                flag = False
+                idx2 += 1
         return indices
 
     def ith_word_diff(self, other_attacked_text, i):


### PR DESCRIPTION
# What does this PR do?

fix terrible match algorithm in `all_words_diff`. See this for detail #451 .. some of the issue text is copied for easier reference

**Describe the bug**
![image](https://user-images.githubusercontent.com/32097922/115559424-48a6c980-a2e6-11eb-8e8e-f72d543aa3a4.png)

**To Reproduce**
Run following command `textattack attack --model cnn-ag-news --recipe textbugger --num-examples 10`

**Expected behavior**
As shown in the pic, the real `Average perturbed word %` should not reach that high. I found the reason in `attack_recipes/shared/attacked_text.py:line 234`.

```python
    def all_words_diff(self, other_attacked_text):
        """Returns the set of indices for which this and other_attacked_text
        have different words."""
        indices = set()
        w1 = self.words
        w2 = other_attacked_text.words
        for i in range(min(len(w1), len(w2))):
            if w1[i] != w2[i]:
                indices.add(i)
        return indices
```

Apparently this comparison according to the absolute position is not proper. I believe we can find another proper algorithm.


after my fix, `Average perturbed word %` drop to about 20%, which it correct.
