### PR TITLE
fix pr 368 to pass pytest

### DIFF
--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -79,7 +79,7 @@ class Augmenter:
         )
         for _ in range(self.transformations_per_example):
             current_text = attacked_text
-            words_swapped = len(current_text.attack_attrs["modified_indices"])
+            words_swapped = max(len(current_text.attack_attrs["modified_indices"]), words_swapped+1)
 
             while words_swapped < num_words_to_swap:
                 transformed_texts = self.transformation(
@@ -98,6 +98,12 @@ class Augmenter:
 
                 # if there's no more transformed texts after filter, terminate
                 if not len(transformed_texts):
+                    break
+                # if transformed texts only contain duplicated words, terminate
+                elif len(set(transformed_texts)) == 1:
+                    break
+                # if there is no synonym to insert, terminate
+                elif transformed_texts == [current_text]:
                     break
 
                 current_text = random.choice(transformed_texts)

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -1,7 +1,6 @@
 """
 Augmenter Class
 ===================
-
 """
 import random
 
@@ -16,7 +15,6 @@ class Augmenter:
 
     Returns all possible transformations for a given string. Currently only
         supports transformations which are word swaps.
-
     Args:
         transformation (textattack.Transformation): the transformation
             that suggests new texts from an input.
@@ -79,7 +77,7 @@ class Augmenter:
         )
         for _ in range(self.transformations_per_example):
             current_text = attacked_text
-            words_swapped = max(len(current_text.attack_attrs["modified_indices"]), words_swapped+1)
+            words_swapped = len(current_text.attack_attrs["modified_indices"])
 
             while words_swapped < num_words_to_swap:
                 transformed_texts = self.transformation(
@@ -99,17 +97,14 @@ class Augmenter:
                 # if there's no more transformed texts after filter, terminate
                 if not len(transformed_texts):
                     break
-                # if transformed texts only contain duplicated words, terminate
-                elif len(set(transformed_texts)) == 1:
-                    break
-                # if there is no synonym to insert, terminate
-                elif transformed_texts == [current_text]:
-                    break
 
                 current_text = random.choice(transformed_texts)
 
                 # update words_swapped based on modified indices
-                words_swapped = len(current_text.attack_attrs["modified_indices"])
+                words_swapped = max(
+                    len(current_text.attack_attrs["modified_indices"]),
+                    words_swapped + 1,
+                )
             all_transformed_texts.add(current_text)
         return sorted([at.printable_text() for at in all_transformed_texts])
 
@@ -119,7 +114,6 @@ class Augmenter:
 
         Args:
             text_list (list(string)): a list of strings for data augmentation
-
         Returns a list(string) of augmented texts.
         """
         if show_progress:

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -15,6 +15,7 @@ class Augmenter:
 
     Returns all possible transformations for a given string. Currently only
         supports transformations which are word swaps.
+
     Args:
         transformation (textattack.Transformation): the transformation
             that suggests new texts from an input.

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -67,7 +67,6 @@ class EasyDataAugmenter(Augmenter):
         augmented_text += self.random_deletion.augment(text)
         augmented_text += self.random_swap.augment(text)
         augmented_text += self.random_insertion.augment(text)
-        augmented_text = list(set(augmented_text))
         random.shuffle(augmented_text)
         return augmented_text[: self.transformations_per_example]
 

--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -67,6 +67,7 @@ class EasyDataAugmenter(Augmenter):
         augmented_text += self.random_deletion.augment(text)
         augmented_text += self.random_swap.augment(text)
         augmented_text += self.random_insertion.augment(text)
+        augmented_text = list(set(augmented_text))
         random.shuffle(augmented_text)
         return augmented_text[: self.transformations_per_example]
 


### PR DESCRIPTION
Addresses pytest issues of https://github.com/QData/TextAttack/pull/368

Here are #368 descriptions
**Problem**
When using `EasyDataAugmenter`, there are two cases that will cause the augmenter to run into an infinite loop. 

Case 1: Text that contains duplicated words e.g. `hello hello hello`

For a sentence / phrase containing duplicated words (`hello hello`), `RandomSwap` would not be able to successfully perform the swap since both words are the same. This causes `words_swapped` to never reach 0 and hence the while loop will never reach its break condition. 

Case 2: Text that contains words with no synonym e.g. `hey derek`

For a sentence / phrase e.g. `hey derek` where there is no synonym that can be inserted, `RandomSynonymInsertion` would not be able to successfully insert a synonym even after 7 attempts. Similarly, this means that `words_swapped` would never reach 0 and hence the while loop will never reach its break condition. 

Here is the while loop which causes the problem:

https://github.com/QData/TextAttack/blob/0cc049a8c77f7f17c9642ac09ca1b60aa17645e8/textattack/augmentation/augmenter.py#L84-L106

**Reproducing the Problem**
Running the following will cause TextAttack augment to enter an infinite loop.

```
from textattack.augmentation import EasyDataAugmenter
augmenter = EasyDataAugmenter()
s = 'hello hello hello' # case 1
s = 'hey derek' # case 2
l = augmenter.augment(s)
print(l)
```

**Fix**

Case 1

We add `len(set(transformed_texts)) == 1` to check if the entire string contains duplicated word. If so, break out of the while loop. 

Case 2

We also break out of the while loop when `transformed_texts == [current_text]`. This happens when the `transformed_texts` is same as the original text (`current_text`) returned after 7 attempts.

https://github.com/QData/TextAttack/blob/0cc049a8c77f7f17c9642ac09ca1b60aa17645e8/textattack/transformations/random_synonym_insertion.py#L31-L36

**Result**
With the fix, running TextAttack augment with `EasyDataAugmenter` will output the expected result.

Case 1
```
['hello hello', 'hello hello howdy', 'hello', 'hello hi']
```

Case 2
```
['derek', 'hey derek', 'derek hey']
```

p.s. also added `augmented_text = list(set(augmented_text))` to remove duplicated results in `EasyDataAugmenter`.


**Then discussions from @Hanyu-Liu-123**

> @DerekChia do you know why some test failed?

I think it is because those 2 fixes will terminate the while loop earlier than we want it to, **when we're not using the `EasyDataAugmenter`.**

For example, for other augmenters, having duplicated words like **"hello hello"** is valid and can be further augmented. It will not cause infinite loop so the augmenting process should not be terminated.

What I think that can fix the infinite loop issue would be to increase `words_swapped` by at least 1 during each iteration of the while loop. We can replace this [line](https://github.com/QData/TextAttack/blob/994a56caf29c7e0162d8fa5ec5d58eab58d30daa/textattack/augmentation/augmenter.py#L106) (`words_swapped = len(current_text.attack_attrs["modified_indices"])`) with `words_swapped = max(len(current_text.attack_attrs["modified_indices"]), words_swapped+1)`. 

In this way, the while loop will iterate at most `num_words_to_swap` times (num_words_to_swap < length of the sentence). It is not pretty but should be able to solve the infinite loop issue without affecting other augmenters.


