### PR TITLE
Update torch version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ nltk
 numpy<1.19.0 #TF 2.0 requires this
 pandas>=1.0.1
 scipy==1.4.1
-torch==1.7.1
+torch>=1.7.0,!=1.8
 transformers>=3.3.0
 terminaltables
 tqdm>=4.27,<4.50.0


### PR DESCRIPTION
# What does this PR do?

Update Pytorch version requirement to be above 1.7.0 but skip 1.8.0

## Summary
Previously, we had to limit Pytorch to 1.7.1 b/c 1.8.0 broke backward compatability for LSTM models. This has been fixed in 1.9.0, so we can just skip 1.8 versions.

## Changes
- Change Pytorch version to be above 1.7.0 but skip 1.8.0
- 
## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [x] Make sure existing tests pass.
- [x] Add relevant tests. No quality testing = no merge.
- [x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
