### PR TITLE
CLI updates .. many don’t work after the API-rework merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,11 @@ textattack train --model bert-base-uncased --dataset glue^cola --batch-size 32 -
 
 ### To check datasets: `textattack peek-dataset`
 
-To take a closer look at a dataset, use `textattack peek-dataset`. TextAttack will print some cursory statistics about the inputs and outputs from the dataset. For example, `textattack peek-dataset --dataset-from-huggingface snli` will show information about the SNLI dataset from the NLP package.
+To take a closer look at a dataset, use `textattack peek-dataset`. TextAttack will print some cursory statistics about the inputs and outputs from the dataset. For example, 
+```bash
+textattack peek-dataset --dataset-from-huggingface snli
+```
+will show information about the SNLI dataset from the NLP package.
 
 
 ### To list functional components: `textattack list`

--- a/docs/1start/FAQ.md
+++ b/docs/1start/FAQ.md
@@ -30,7 +30,7 @@ For help and realtime updates related to TextAttack, please [join the TextAttack
 
 ### 0. For many of the dependent library issues, the following command is the first you could try: 
 ```bash
-pip install --force-reinstall textattack
+pip install --upgrade --force-reinstall textattack
 ```
 
 Besides, we highly recommend you to use virtual environment for textattack use, 

--- a/docs/1start/support.md
+++ b/docs/1start/support.md
@@ -121,7 +121,7 @@ Follow these steps to start contributing:
    
    ```bash
    $ cd TextAttack
-   $ pip install -e . ".[dev]"
+   $ pip install -e .[dev]
    $ pip install black isort pytest pytest-xdist
    ```
    


### PR DESCRIPTION
# What does this PR do?

## Summary
*Many of the CLI funcs (e.g. those in README.md) do not work anymore..
Tried to run them using textattack==0.2.15…. all commands are correct…
When switching to most recent 0.3.0 and the now-master version..most CLI line use do not work..
It seems all tutorials are working… because the majority are library API use…
Now … clearly something is wrong in the CLI part…

* Four main types of errors:*
1. output dimension do not match… e.g. .. running: 
```
textattack attack --model cnn-ag-news --recipe textbugger --num-examples 10
```

2. model does not load correctly: e.g. 
```
textattack attack --model distilbert-base-uncased-qqp --recipe deepwordbug --num-examples 100
```
3.  … out of RAM errors..
e.g.. 
```
textattack attack --recipe textfooler --model bert-base-uncased-mr --num-examples 100
```
4. .. training arg parsing issues:
e.g. 
```
textattack train --model lstm --dataset yelp_polarity --batch-size 64 --epochs 50 --learning-rate 1e-5
```

## Changes
- **

## Deletions
- **

## Checklist
- [ x] The title of your pull request should be a summary of its contribution.
- [  ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
