### PR TITLE
fix document errors and inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,14 +296,15 @@ textattack attack --model bert-base-uncased-sst2 --recipe textfooler --num-examp
 ### Augmenting Text: `textattack augment`
 
 Many of the components of TextAttack are useful for data augmentation. The `textattack.Augmenter` class
-uses a transformation and a list of constraints to augment data. We also offer five built-in recipes
+uses a transformation and a list of constraints to augment data. We also offer  built-in recipes
 for data augmentation:
-- `textattack.WordNetAugmenter` augments text by replacing words with WordNet synonyms
-- `textattack.EmbeddingAugmenter` augments text by replacing words with neighbors in the counter-fitted embedding space, with a constraint to ensure their cosine similarity is at least 0.8
-- `textattack.CharSwapAugmenter` augments text by substituting, deleting, inserting, and swapping adjacent characters
-- `textattack.EasyDataAugmenter` augments text with a combination of word insertions, substitutions and deletions.
-- `textattack.CheckListAugmenter` augments text by contraction/extension and by substituting names, locations, numbers.
-- `textattack.CLAREAugmenter` augments text by replacing, inserting, and merging with a pre-trained masked language model.
+- `wordnet` augments text by replacing words with WordNet synonyms
+- `embedding` augments text by replacing words with neighbors in the counter-fitted embedding space, with a constraint to ensure their cosine similarity is at least 0.8
+- `charswap` augments text by substituting, deleting, inserting, and swapping adjacent characters
+- `eda` augments text with a combination of word insertions, substitutions and deletions.
+- `checklist` augments text by contraction/extension and by substituting names, locations, numbers.
+- `clare` augments text by replacing, inserting, and merging with a pre-trained masked language model.
+
 
 #### Augmentation Command-Line Interface
 The easiest way to use our data augmentation tools is with `textattack augment <args>`. `textattack augment`

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -292,11 +292,14 @@ textattack attack --model bert-base-uncased-sst2 --recipe textfooler --num-examp
 ### 增强文本数据：`textattack augment`
 
 TextAttack 的组件中，有很多易用的数据增强工具。`textattack.Augmenter` 类使用 *变换* 与一系列的 *约束* 进行数据增强。我们提供了 5 中内置的数据增强策略：
-- `textattack.WordNetAugmenter` 通过基于 WordNet 同义词替换的方式增强文本
-- `textattack.EmbeddingAugmenter` 通过邻近词替换的方式增强文本，使用 counter-fitted 词嵌入空间中的邻近词进行替换，约束二者的 cosine 相似度不低于 0.8
-- `textattack.CharSwapAugmenter` 通过字符的增删改，以及临近字符交换的方式增强文本
-- `textattack.EasyDataAugmenter` 通过对词的增删改来增强文本
-- `textattack.CheckListAugmenter` 通过简写，扩写以及对实体、地点、数字的替换来增强文本
+- `wordnet` 通过基于 WordNet 同义词替换的方式增强文本
+- `embedding` 通过邻近词替换的方式增强文本，使用 counter-fitted 词嵌入空间中的邻近词进行替换，约束二者的 cosine 相似度不低于 0.8
+- `charswap` 通过字符的增删改，以及临近字符交换的方式增强文本
+- `eda` 通过对词的增删改来增强文本
+- `checklist` 通过简写，扩写以及对实体、地点、数字的替换来增强文本
+- `clare` 使用 pre-trained masked language model, 通过对词的增删改来增强文本
+
+
 
 #### 数据增强的命令行接口
 使用 textattack 来进行数据增强，最快捷的方法是通过 `textattack augment <args>` 命令行接口。 `textattack augment` 使用 CSV 文件作为输入，在参数中设置需要增强的文本列，每个样本允许改变的比例，以及对于每个输入样本生成多少个增强样本。输出的结果保存为与输入文件格式一致的 CSV 文件，结果文件中为对指定的文本列生成的增强样本。

--- a/docs/3recipes/augmenter_recipes.rst
+++ b/docs/3recipes/augmenter_recipes.rst
@@ -7,25 +7,27 @@ In addition to the command-line interface, you can augment text dynamically by i
 `Augmenter` in your own code. All `Augmenter` objects implement `augment` and `augment_many` to generate augmentations
 of a string or a list of strings. Here's an example of how to use the `EmbeddingAugmenter` in a python script:
 
-```python
->>> from textattack.augmentation import EmbeddingAugmenter
->>> augmenter = EmbeddingAugmenter()
->>> s = 'What I cannot create, I do not understand.'
->>> augmenter.augment(s)
-['What I notable create, I do not understand.', 'What I significant create, I do not understand.', 'What I cannot engender, I do not understand.', 'What I cannot creating, I do not understand.', 'What I cannot creations, I do not understand.', 'What I cannot create, I do not comprehend.', 'What I cannot create, I do not fathom.', 'What I cannot create, I do not understanding.', 'What I cannot create, I do not understands.', 'What I cannot create, I do not understood.', 'What I cannot create, I do not realise.']
-```
+.. code-block:: python
+
+   >>> from textattack.augmentation import EmbeddingAugmenter
+   >>> augmenter = EmbeddingAugmenter()
+   >>> s = 'What I cannot create, I do not understand.'
+   >>> augmenter.augment(s)
+   ['What I notable create, I do not understand.', 'What I significant create, I do not understand.', 'What I cannot engender, I do not understand.', 'What I cannot creating, I do not understand.', 'What I cannot creations, I do not understand.', 'What I cannot create, I do not comprehend.', 'What I cannot create, I do not fathom.', 'What I cannot create, I do not understanding.', 'What I cannot create, I do not understands.', 'What I cannot create, I do not understood.', 'What I cannot create, I do not realise.']
+
 You can also create your own augmenter from scratch by importing transformations/constraints from `textattack.transformations` and `textattack.constraints`. Here's an example that generates augmentations of a string using `WordSwapRandomCharacterDeletion`:
 
-```python
->>> from textattack.transformations import WordSwapRandomCharacterDeletion
->>> from textattack.transformations import CompositeTransformation
->>> from textattack.augmentation import Augmenter
->>> transformation = CompositeTransformation([WordSwapRandomCharacterDeletion()])
->>> augmenter = Augmenter(transformation=transformation, transformations_per_example=5)
->>> s = 'What I cannot create, I do not understand.'
->>> augmenter.augment(s)
-['What I cannot creae, I do not understand.', 'What I cannot creat, I do not understand.', 'What I cannot create, I do not nderstand.', 'What I cannot create, I do nt understand.', 'Wht I cannot create, I do not understand.']
-```
+.. code-block:: python
+
+   >>> from textattack.transformations import WordSwapRandomCharacterDeletion
+   >>> from textattack.transformations import CompositeTransformation
+   >>> from textattack.augmentation import Augmenter
+   >>> transformation = CompositeTransformation([WordSwapRandomCharacterDeletion()])
+   >>> augmenter = Augmenter(transformation=transformation, transformations_per_example=5)
+   >>> s = 'What I cannot create, I do not understand.'
+   >>> augmenter.augment(s)
+   ['What I cannot creae, I do not understand.', 'What I cannot creat, I do not understand.', 'What I cannot create, I do not nderstand.', 'What I cannot create, I do nt understand.', 'Wht I cannot create, I do not understand.']
+
 
 
 Here is a list of recipes for NLP data augmentations

--- a/docs/3recipes/augmenter_recipes_cmd.md
+++ b/docs/3recipes/augmenter_recipes_cmd.md
@@ -7,17 +7,18 @@ The [`examples/`](https://github.com/QData/TextAttack/tree/master/examples) fold
 The [documentation website](https://textattack.readthedocs.io/en/latest) contains walkthroughs explaining basic usage of TextAttack, including building a custom transformation and a custom constraint..
 
 
-## Augmenting Text: `textattack augment`
+### Augmenting Text: `textattack augment`
 
 Many of the components of TextAttack are useful for data augmentation. The `textattack.Augmenter` class
-uses a transformation and a list of constraints to augment data. We also offer five built-in recipes
+uses a transformation and a list of constraints to augment data. We also offer  built-in recipes
 for data augmentation:
-- `textattack.WordNetAugmenter` augments text by replacing words with WordNet synonyms
-- `textattack.EmbeddingAugmenter` augments text by replacing words with neighbors in the counter-fitted embedding space, with a constraint to ensure their cosine similarity is at least 0.8
-- `textattack.CharSwapAugmenter` augments text by substituting, deleting, inserting, and swapping adjacent characters
-- `textattack.EasyDataAugmenter` augments text with a combination of word insertions, substitutions and deletions.
-- `textattack.CheckListAugmenter` augments text by contraction/extension and by substituting names, locations, numbers.
-- `textattack.CLAREAugmenter` augments text by replacing, inserting, and merging with a pre-trained masked language model.
+- `wordnet` augments text by replacing words with WordNet synonyms
+- `embedding` augments text by replacing words with neighbors in the counter-fitted embedding space, with a constraint to ensure their cosine similarity is at least 0.8
+- `charswap` augments text by substituting, deleting, inserting, and swapping adjacent characters
+- `eda` augments text with a combination of word insertions, substitutions and deletions.
+- `checklist` augments text by contraction/extension and by substituting names, locations, numbers.
+- `clare` augments text by replacing, inserting, and merging with a pre-trained masked language model.
+
 
 ### Augmentation Command-Line Interface
 The easiest way to use our data augmentation tools is with `textattack augment <args>`. 

--- a/docs/api/constraints.rst
+++ b/docs/api/constraints.rst
@@ -3,11 +3,11 @@ Constraints API Reference
 
 Constraint
 ------------
-.. automodule:: textattack.constraints.Constraint
+.. autoclass:: textattack.constraints.Constraint
    :members:
 
 PreTransformationConstraint
 -----------------------------
-.. automodule:: textattack.constraints.PreTransformationConstraint
+.. autoclass:: textattack.constraints.PreTransformationConstraint
     :members:
 

--- a/docs/apidoc/textattack.attack_recipes.rst
+++ b/docs/apidoc/textattack.attack_recipes.rst
@@ -6,8 +6,6 @@ textattack.attack\_recipes package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.attack_recipes.attack_recipe

--- a/docs/apidoc/textattack.attack_results.rst
+++ b/docs/apidoc/textattack.attack_results.rst
@@ -6,8 +6,6 @@ textattack.attack\_results package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.attack_results.attack_result

--- a/docs/apidoc/textattack.augmentation.rst
+++ b/docs/apidoc/textattack.augmentation.rst
@@ -6,8 +6,6 @@ textattack.augmentation package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.augmentation.augmenter

--- a/docs/apidoc/textattack.commands.rst
+++ b/docs/apidoc/textattack.commands.rst
@@ -6,8 +6,6 @@ textattack.commands package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.commands.attack_command

--- a/docs/apidoc/textattack.constraints.grammaticality.language_models.google_language_model.rst
+++ b/docs/apidoc/textattack.constraints.grammaticality.language_models.google_language_model.rst
@@ -6,8 +6,6 @@ textattack.constraints.grammaticality.language\_models.google\_language\_model p
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.grammaticality.language_models.google_language_model.alzantot_goog_lm

--- a/docs/apidoc/textattack.constraints.grammaticality.language_models.learning_to_write.rst
+++ b/docs/apidoc/textattack.constraints.grammaticality.language_models.learning_to_write.rst
@@ -6,8 +6,6 @@ textattack.constraints.grammaticality.language\_models.learning\_to\_write packa
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.grammaticality.language_models.learning_to_write.adaptive_softmax

--- a/docs/apidoc/textattack.constraints.grammaticality.language_models.rst
+++ b/docs/apidoc/textattack.constraints.grammaticality.language_models.rst
@@ -6,8 +6,6 @@ textattack.constraints.grammaticality.language\_models package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
@@ -15,8 +13,6 @@ Subpackages
    textattack.constraints.grammaticality.language_models.google_language_model
    textattack.constraints.grammaticality.language_models.learning_to_write
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.grammaticality.language_models.gpt2

--- a/docs/apidoc/textattack.constraints.grammaticality.rst
+++ b/docs/apidoc/textattack.constraints.grammaticality.rst
@@ -6,16 +6,12 @@ textattack.constraints.grammaticality package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
 
    textattack.constraints.grammaticality.language_models
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.grammaticality.cola

--- a/docs/apidoc/textattack.constraints.overlap.rst
+++ b/docs/apidoc/textattack.constraints.overlap.rst
@@ -6,8 +6,6 @@ textattack.constraints.overlap package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.overlap.bleu_score

--- a/docs/apidoc/textattack.constraints.pre_transformation.rst
+++ b/docs/apidoc/textattack.constraints.pre_transformation.rst
@@ -6,8 +6,6 @@ textattack.constraints.pre\_transformation package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.pre_transformation.input_column_modification

--- a/docs/apidoc/textattack.constraints.rst
+++ b/docs/apidoc/textattack.constraints.rst
@@ -6,8 +6,6 @@ textattack.constraints package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
@@ -17,8 +15,6 @@ Subpackages
    textattack.constraints.pre_transformation
    textattack.constraints.semantics
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.constraint

--- a/docs/apidoc/textattack.constraints.semantics.rst
+++ b/docs/apidoc/textattack.constraints.semantics.rst
@@ -6,16 +6,12 @@ textattack.constraints.semantics package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
 
    textattack.constraints.semantics.sentence_encoders
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.semantics.bert_score

--- a/docs/apidoc/textattack.constraints.semantics.sentence_encoders.bert.rst
+++ b/docs/apidoc/textattack.constraints.semantics.sentence_encoders.bert.rst
@@ -6,8 +6,6 @@ textattack.constraints.semantics.sentence\_encoders.bert package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.semantics.sentence_encoders.bert.bert

--- a/docs/apidoc/textattack.constraints.semantics.sentence_encoders.infer_sent.rst
+++ b/docs/apidoc/textattack.constraints.semantics.sentence_encoders.infer_sent.rst
@@ -6,8 +6,6 @@ textattack.constraints.semantics.sentence\_encoders.infer\_sent package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.semantics.sentence_encoders.infer_sent.infer_sent

--- a/docs/apidoc/textattack.constraints.semantics.sentence_encoders.rst
+++ b/docs/apidoc/textattack.constraints.semantics.sentence_encoders.rst
@@ -6,8 +6,6 @@ textattack.constraints.semantics.sentence\_encoders package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
@@ -16,8 +14,6 @@ Subpackages
    textattack.constraints.semantics.sentence_encoders.infer_sent
    textattack.constraints.semantics.sentence_encoders.universal_sentence_encoder
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.semantics.sentence_encoders.sentence_encoder

--- a/docs/apidoc/textattack.constraints.semantics.sentence_encoders.universal_sentence_encoder.rst
+++ b/docs/apidoc/textattack.constraints.semantics.sentence_encoders.universal_sentence_encoder.rst
@@ -6,8 +6,6 @@ textattack.constraints.semantics.sentence\_encoders.universal\_sentence\_encoder
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.constraints.semantics.sentence_encoders.universal_sentence_encoder.multilingual_universal_sentence_encoder

--- a/docs/apidoc/textattack.datasets.helpers.rst
+++ b/docs/apidoc/textattack.datasets.helpers.rst
@@ -6,8 +6,6 @@ textattack.datasets.helpers package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.datasets.helpers.ted_multi

--- a/docs/apidoc/textattack.datasets.rst
+++ b/docs/apidoc/textattack.datasets.rst
@@ -6,16 +6,12 @@ textattack.datasets package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
 
    textattack.datasets.helpers
 
-Submodules
-----------
 
 
 .. automodule:: textattack.datasets.dataset

--- a/docs/apidoc/textattack.goal_function_results.rst
+++ b/docs/apidoc/textattack.goal_function_results.rst
@@ -6,8 +6,6 @@ textattack.goal\_function\_results package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.goal_function_results.classification_goal_function_result

--- a/docs/apidoc/textattack.goal_functions.classification.rst
+++ b/docs/apidoc/textattack.goal_functions.classification.rst
@@ -6,8 +6,6 @@ textattack.goal\_functions.classification package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.goal_functions.classification.classification_goal_function

--- a/docs/apidoc/textattack.goal_functions.rst
+++ b/docs/apidoc/textattack.goal_functions.rst
@@ -6,8 +6,6 @@ textattack.goal\_functions package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
@@ -15,8 +13,6 @@ Subpackages
    textattack.goal_functions.classification
    textattack.goal_functions.text
 
-Submodules
-----------
 
 
 .. automodule:: textattack.goal_functions.goal_function

--- a/docs/apidoc/textattack.goal_functions.text.rst
+++ b/docs/apidoc/textattack.goal_functions.text.rst
@@ -6,8 +6,6 @@ textattack.goal\_functions.text package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.goal_functions.text.minimize_bleu

--- a/docs/apidoc/textattack.loggers.rst
+++ b/docs/apidoc/textattack.loggers.rst
@@ -6,8 +6,6 @@ textattack.loggers package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.loggers.attack_log_manager

--- a/docs/apidoc/textattack.models.helpers.rst
+++ b/docs/apidoc/textattack.models.helpers.rst
@@ -6,8 +6,6 @@ textattack.models.helpers package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.models.helpers.glove_embedding_layer

--- a/docs/apidoc/textattack.models.rst
+++ b/docs/apidoc/textattack.models.rst
@@ -6,8 +6,6 @@ textattack.models package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6

--- a/docs/apidoc/textattack.models.tokenizers.rst
+++ b/docs/apidoc/textattack.models.tokenizers.rst
@@ -6,8 +6,6 @@ textattack.models.tokenizers package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.models.tokenizers.glove_tokenizer

--- a/docs/apidoc/textattack.models.wrappers.rst
+++ b/docs/apidoc/textattack.models.wrappers.rst
@@ -6,8 +6,6 @@ textattack.models.wrappers package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.models.wrappers.huggingface_model_wrapper

--- a/docs/apidoc/textattack.rst
+++ b/docs/apidoc/textattack.rst
@@ -6,8 +6,6 @@ textattack package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
@@ -26,8 +24,6 @@ Subpackages
    textattack.shared
    textattack.transformations
 
-Submodules
-----------
 
 
 .. automodule:: textattack.attack

--- a/docs/apidoc/textattack.search_methods.rst
+++ b/docs/apidoc/textattack.search_methods.rst
@@ -6,8 +6,6 @@ textattack.search\_methods package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.search_methods.alzantot_genetic_algorithm

--- a/docs/apidoc/textattack.shared.rst
+++ b/docs/apidoc/textattack.shared.rst
@@ -6,16 +6,12 @@ textattack.shared package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
 
    textattack.shared.utils
 
-Submodules
-----------
 
 
 .. automodule:: textattack.shared.attacked_text

--- a/docs/apidoc/textattack.shared.utils.rst
+++ b/docs/apidoc/textattack.shared.utils.rst
@@ -6,8 +6,6 @@ textattack.shared.utils package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.shared.utils.importing

--- a/docs/apidoc/textattack.transformations.rst
+++ b/docs/apidoc/textattack.transformations.rst
@@ -6,8 +6,6 @@ textattack.transformations package
    :undoc-members:
    :show-inheritance:
 
-Subpackages
------------
 
 .. toctree::
    :maxdepth: 6
@@ -16,8 +14,6 @@ Subpackages
    textattack.transformations.word_merges
    textattack.transformations.word_swaps
 
-Submodules
-----------
 
 
 .. automodule:: textattack.transformations.composite_transformation

--- a/docs/apidoc/textattack.transformations.word_insertions.rst
+++ b/docs/apidoc/textattack.transformations.word_insertions.rst
@@ -6,8 +6,6 @@ textattack.transformations.word\_insertions package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.transformations.word_insertions.word_insertion

--- a/docs/apidoc/textattack.transformations.word_merges.rst
+++ b/docs/apidoc/textattack.transformations.word_merges.rst
@@ -6,8 +6,6 @@ textattack.transformations.word\_merges package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.transformations.word_merges.word_merge

--- a/docs/apidoc/textattack.transformations.word_swaps.rst
+++ b/docs/apidoc/textattack.transformations.word_swaps.rst
@@ -6,8 +6,6 @@ textattack.transformations.word\_swaps package
    :undoc-members:
    :show-inheritance:
 
-Submodules
-----------
 
 
 .. automodule:: textattack.transformations.word_swaps.word_swap

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ TextAttack Documentation
    Trainer <api/trainer.rst>
    Datasets <api/datasets.rst>
    GoalFunction <api/goal_functions.rst>
-   Constraints <api/constraints/constraints.rst>
+   Constraints <api/constraints.rst>
    SearchMethod <api/search_methods.rst>
    
 


### PR DESCRIPTION
# What does this PR do?

## Summary
*Inconsistency between read-the-doc and locally built of the documentations*

## Changes
- clean up the doc/apidoc folder, removing unhelpful submodule/subpackage headers
- clean up the doc/api folder, by correcting constraint folder 
- correcting those mentions of augmentation.recipe in README.md

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [x] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
