### PR TITLE
adding the missed docstrings for api-rework-modules

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,7 @@ copyright = "2020, UVA QData Lab"
 author = "UVA QData Lab"
 
 # The full version, including alpha/beta/rc tags
-release = "0.3.2"
+release = "0.3.3"
 
 # Set master doc to `index.rst`.
 master_doc = "index"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -28,5 +28,4 @@ tensorflow-text==2.4.2
 tensorflow-hub==0.12.0
 textattack==0.3.2
 transformers==4.9.1
-virtualenv==20.0.18
 pillow>=8.2.0

--- a/textattack/attack.py
+++ b/textattack/attack.py
@@ -1,5 +1,5 @@
 """
-Attack Class 
+Attack Class
 ============
 """
 

--- a/textattack/attack.py
+++ b/textattack/attack.py
@@ -1,3 +1,8 @@
+"""
+Attack Class 
+============
+"""
+
 from collections import OrderedDict
 from typing import List, Union
 

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -1,3 +1,8 @@
+"""
+AttackArgs Class 
+================
+"""
+
 from dataclasses import dataclass, field
 import json
 import os

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -1,5 +1,5 @@
 """
-AttackArgs Class 
+AttackArgs Class
 ================
 """
 

--- a/textattack/attacker.py
+++ b/textattack/attacker.py
@@ -1,3 +1,8 @@
+"""
+Attacker Class 
+==============
+"""
+
 import collections
 import logging
 import multiprocessing as mp

--- a/textattack/attacker.py
+++ b/textattack/attacker.py
@@ -1,5 +1,5 @@
 """
-Attacker Class 
+Attacker Class
 ==============
 """
 

--- a/textattack/augment_args.py
+++ b/textattack/augment_args.py
@@ -1,5 +1,5 @@
 """
-AugmenterArgs Class 
+AugmenterArgs Class
 ===================
 """
 

--- a/textattack/augment_args.py
+++ b/textattack/augment_args.py
@@ -1,3 +1,9 @@
+"""
+AugmenterArgs Class 
+===================
+"""
+
+
 from dataclasses import dataclass
 
 AUGMENTATION_RECIPE_NAMES = {

--- a/textattack/dataset_args.py
+++ b/textattack/dataset_args.py
@@ -1,5 +1,5 @@
 """
-DatasetArgs Class 
+DatasetArgs Class
 =================
 """
 

--- a/textattack/dataset_args.py
+++ b/textattack/dataset_args.py
@@ -1,3 +1,8 @@
+"""
+DatasetArgs Class 
+=================
+"""
+
 from dataclasses import dataclass
 
 import textattack

--- a/textattack/model_args.py
+++ b/textattack/model_args.py
@@ -1,5 +1,5 @@
 """
-ModelArgs Class 
+ModelArgs Class
 ===============
 """
 

--- a/textattack/model_args.py
+++ b/textattack/model_args.py
@@ -1,3 +1,9 @@
+"""
+ModelArgs Class 
+===============
+"""
+
+
 from dataclasses import dataclass
 import json
 import os

--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -1,5 +1,5 @@
 """
-Trainer Class 
+Trainer Class
 =============
 """
 

--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -1,3 +1,8 @@
+"""
+Trainer Class 
+=============
+"""
+
 import collections
 import json
 import logging

--- a/textattack/training_args.py
+++ b/textattack/training_args.py
@@ -1,3 +1,8 @@
+"""
+TrainingArgs Class 
+==================
+"""
+
 from dataclasses import dataclass, field
 import datetime
 import os

--- a/textattack/training_args.py
+++ b/textattack/training_args.py
@@ -1,5 +1,5 @@
 """
-TrainingArgs Class 
+TrainingArgs Class
 ==================
 """
 


### PR DESCRIPTION
# What does this PR do?

## Summary
* api-rework added multiple modules in the textattack root level. however all are missing docstring; these made the readthedoc API reference missing these modules*

## Additions
- *added docstrings at the beginning of each new module added by api-rework  in the textattack root level*

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
