### PR TITLE
Fix a bug when running textattack eval with --num-examples=-1

### DIFF
--- a/textattack/commands/eval_model_command.py
+++ b/textattack/commands/eval_model_command.py
@@ -39,6 +39,8 @@ class EvalModelCommand(TextAttackCommand):
     def test_model_on_dataset(self, args):
         model = ModelArgs._create_model_from_args(args)
         dataset = DatasetArgs._create_dataset_from_args(args)
+        if args.num_examples == -1:
+            args.num_examples = len(dataset)
 
         preds = []
         ground_truth_outputs = []


### PR DESCRIPTION
# What does this PR do?
Fix a bug when running `textattack eval` with `--num-examples=-1` in CLI.

## Summary
When running `textattack eval --num-examples=-1 ...`, it should be treated as `num_examples = len(dataset)` and evaluate the entire dataset. However, the code does not handle this case, the main loop is never executed, and it returns `preds=[]`.

## Additions
- Add value check for `num_examples` before executing the main evaluation loop.

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [ ] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'