### PR TITLE
Fix dataset-split bug

### DIFF
--- a/textattack/dataset_args.py
+++ b/textattack/dataset_args.py
@@ -275,7 +275,9 @@ class DatasetArgs:
                     dataset_args = (dataset_args,)
             if args.dataset_split:
                 if len(dataset_args) > 1:
-                    dataset_args = dataset_args[:1] + (args.dataset_split,) + dataset_args[2:]
+                    dataset_args = (
+                        dataset_args[:1] + (args.dataset_split,) + dataset_args[2:]
+                    )
                     dataset = textattack.datasets.HuggingFaceDataset(
                         *dataset_args, shuffle=False
                     )

--- a/textattack/dataset_args.py
+++ b/textattack/dataset_args.py
@@ -275,7 +275,7 @@ class DatasetArgs:
                     dataset_args = (dataset_args,)
             if args.dataset_split:
                 if len(dataset_args) > 1:
-                    dataset_args[2] = args.dataset_split
+                    dataset_args = dataset_args[:1] + (args.dataset_split,) + dataset_args[2:]
                     dataset = textattack.datasets.HuggingFaceDataset(
                         *dataset_args, shuffle=False
                     )


### PR DESCRIPTION
# What does this PR do?

## Summary
In  [dataset_args.py](https://github.com/QData/TextAttack/blob/master/textattack/dataset_args.py), the function `_create_dataset_from_args()` tries to substitute the second element of `dataset_args`(a tuple) with user input from command line. This gives an error since elements of a tuple cannot be changed.

## Additions
- NA

## Changes
Create a new tuple with substituted value for the second element of `dataset_args`

## Deletions
- NA

## Checklist
- *[x] The title of your pull request should be a summary of its contribution.
- *[x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- *[x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- *[x] To indicate a work in progress please mark it as a draft on Github.
- *[x] Make sure existing tests pass.
- *[x] Add relevant tests. No quality testing = no merge.
- *[x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
