### PR TITLE
Fix logger initiation bug

### DIFF
--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -24,8 +24,9 @@ from .model_args import HUGGINGFACE_MODELS
 from .models.helpers import LSTMForClassification, WordCNNForClassification
 from .models.wrappers import ModelWrapper
 from .training_args import CommandLineTrainingArgs, TrainingArgs
+import textattack.shared as util_shared
 
-logger = textattack.shared.logger
+logger = util_shared.logger
 
 
 class Trainer:

--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -25,8 +25,9 @@ from .models.helpers import LSTMForClassification, WordCNNForClassification
 from .models.wrappers import ModelWrapper
 from .training_args import CommandLineTrainingArgs, TrainingArgs
 import textattack.shared as util_shared
+from .shared.utils.install import logger as the_logger
 
-logger = util_shared.logger
+logger = the_logger
 
 
 class Trainer:

--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -23,11 +23,10 @@ from .attacker import Attacker
 from .model_args import HUGGINGFACE_MODELS
 from .models.helpers import LSTMForClassification, WordCNNForClassification
 from .models.wrappers import ModelWrapper
+from .shared.utils.install import logger
 from .training_args import CommandLineTrainingArgs, TrainingArgs
-import textattack.shared as util_shared
-from .shared.utils.install import logger as the_logger
 
-logger = the_logger
+logger = logger
 
 
 class Trainer:


### PR DESCRIPTION
# What does this PR do?

## Summary
When running in Google Colab, the [logger initiation line](https://github.com/QData/TextAttack/blob/caacc1c8a7ea9acdd9c88e104abceb8e9352ae4a/textattack/trainer.py#L28r) returns an Attribution error like the following:

```
AttributeError: module 'textattack' has no attribute 'shared'
```

This is probably due to the ambiguous path that the current logger initiation uses, or an issue with the import loop that was also encountered in this [issue](https://github.com/QData/TextAttack/issues/110).

## Changes
Change from `logger = textattack.shared.logger` to `logger = textattack.shared.utils.logger`

## Checklist
- *[x] The title of your pull request should be a summary of its contribution.
- *[x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- *[x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- *[x] To indicate a work in progress please mark it as a draft on Github.
- *[x] Make sure existing tests pass.
- *[x] Add relevant tests. No quality testing = no merge.
- *[x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
