### PR TITLE
Fixed the logger bug

### DIFF
--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -25,7 +25,7 @@ from .models.helpers import LSTMForClassification, WordCNNForClassification
 from .models.wrappers import ModelWrapper
 from .training_args import CommandLineTrainingArgs, TrainingArgs
 
-logger = textattack.shared.utils.logger
+from textattack.shared.utils import logger
 
 
 class Trainer:


### PR DESCRIPTION
# What does this PR do?
Solves the "module 'textattack' has no attribute 'shared'" error that comes up whenever doing "from textattack.augmentation import EmbeddingAugmenter".

Before Change:
<img width="696" alt="loggerbug_before" src="https://user-images.githubusercontent.com/90351130/138377868-503ff036-a955-4ae7-8225-0efab244e17f.png">

After Change:
<img width="1119" alt="loggerbug_after" src="https://user-images.githubusercontent.com/90351130/138377874-721bce00-ee9b-4d57-a29d-32cbe544cffe.png">

## Summary
Earlier, there was "logger = textattack.shared.utils.logger", but according to https://stackoverflow.com/questions/8899198/module-has-no-attribute and the current way that attacker.py uses logger (https://github.com/QData/TextAttack/blob/907ec46556d8c36bfe62b4db0484dfcbd9b706db/textattack/attacker.py), it looks like the best way to solve the problem is to replace the line with a direct import. The problem earlier was that there was no direct way to get the attribute logger, but this PR should fix that problem.

## Additions
- The line "from textattack.shared.utils import logger" has been added.

## Changes
- The line "logger = textattack.shared.utils.logger" has been changed to "from textattack.shared.utils import logger".

## Deletions
- The line  "logger = textattack.shared.utils.logger" has been deleted.

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [ ] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
