### PR TITLE
Fixed the "no attribute" error from #536

### DIFF
--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -10,12 +10,13 @@ import nltk
 
 import textattack
 from textattack.constraints import Constraint
+from textattack.shared.utils import LazyLoader, device
 from textattack.shared.validators import transformation_consists_of_word_swaps
 
 # Set global flair device to be TextAttack's current device
-flair.device = textattack.shared.utils.device
+flair.device = device
 
-stanza = textattack.shared.utils.LazyLoader("stanza", globals(), "stanza")
+stanza = LazyLoader("stanza", globals(), "stanza")
 
 
 class PartOfSpeech(Constraint):


### PR DESCRIPTION
# What does this PR do?
This change fixes "AttributeError: module 'textattack' has no attribute 'shared'" as shown by issue 536 here: https://github.com/QData/TextAttack/issues/536

## Summary
Before this PR, users were running into the problem of "AttributeError: module 'textattack' has no attribute 'shared'" whenever they were running the part_of_speech.py file. This PR uses the same logic from https://github.com/QData/TextAttack/pull/551 which solves the problem of the attribute not belonging to the module using a direct import of the module.

## Additions
- The line "from textattack.shared.utils import LazyLoader, device" has been added.

## Changes
- Changed "flair.device = textattack.shared.utils.device" to be "flair.device = device"
- Changed "stanza = textattack.shared.utils.LazyLoader("stanza", globals(), "stanza")" to be "stanza = LazyLoader("stanza", globals(), "stanza")"

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [ ] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
