### PR TITLE
Fix CLARE Extra Character Bug

### DIFF
--- a/textattack/transformations/word_insertions/word_insertion_masked_lm.py
+++ b/textattack/transformations/word_insertions/word_insertion_masked_lm.py
@@ -155,6 +155,7 @@ class WordInsertionMaskedLM(WordInsertion):
             index_to_modify = indices_to_modify[i]
             word_at_index = current_text.words[index_to_modify]
             for word in new_words[i]:
+                word = word.strip("Ġ")
                 if word != word_at_index:
                     transformed_texts.append(
                         current_text.insert_text_before_word_index(

--- a/textattack/transformations/word_merges/word_merge_masked_lm.py
+++ b/textattack/transformations/word_merges/word_merge_masked_lm.py
@@ -162,6 +162,7 @@ class WordMergeMaskedLM(Transformation):
             index_to_modify = merge_indices[i]
             word_at_index = current_text.words[index_to_modify]
             for word in merged_words[i]:
+                word = word.strip("Ġ")
                 if word != word_at_index:
                     temp_text = current_text.delete_word_at_index(index_to_modify + 1)
                     transformed_texts.append(

--- a/textattack/transformations/word_swaps/word_swap_masked_lm.py
+++ b/textattack/transformations/word_swaps/word_swap_masked_lm.py
@@ -272,6 +272,7 @@ class WordSwapMaskedLM(WordSwap):
                 )
 
                 for r in replacement_words:
+                    r = r.strip("Ġ")
                     if r != word_at_index:
                         transformed_texts.append(
                             current_text.replace_word_at_index(i, r)
@@ -288,6 +289,7 @@ class WordSwapMaskedLM(WordSwap):
                 index_to_modify = indices_to_modify[i]
                 word_at_index = current_text.words[index_to_modify]
                 for word in replacement_words[i]:
+                    word = word.strip("Ġ")
                     if word != word_at_index and len(utils.words_from_text(word)) == 1:
                         transformed_texts.append(
                             current_text.replace_word_at_index(index_to_modify, word)


### PR DESCRIPTION
# What does this PR do?

## Summary
When the CLAREAugmenter substitutes a word, there's an extra character that is added to the front (Ġ). The CLARE transformation method should remove that extra character before the transformed text is returned by the transformation.

## Additions
- Before a sentence is transformed, strip the substituting words of `Ġ` so that it doesn't appear in transformation.

## Checklist
- *[x] The title of your pull request should be a summary of its contribution.
- *[x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- *[x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- *[x] To indicate a work in progress please mark it as a draft on Github.
- *[x] Make sure existing tests pass.
- *[x] Add relevant tests. No quality testing = no merge.
- *[x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
