### PR TITLE
Add API docstrings for back translation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extras["tensorflow"] = [
     "tensorflow_hub",
     "tensorflow_text>=2",
     "tensorboardX",
-    "tensorflow-estimator==2.6.0",
+    "tensorflow-estimator==2.5.0",
 ]
 
 extras["optional"] = [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ extras["test"] = [
 ]
 
 extras["tensorflow"] = [
-    "tensorflow>=2",
+    "tensorflow==2.5.0",
     "tensorflow_hub",
     "tensorflow_text>=2",
     "tensorboardX",

--- a/tests/test_augment_api.py
+++ b/tests/test_augment_api.py
@@ -97,8 +97,7 @@ def test_back_translation():
     from textattack.augmentation import Augmenter
     from textattack.transformations.sentence_transformations import BackTranslation
 
-    transformation = BackTranslation
-    augmenter = Augmenter(transformation=transformation)
+    augmenter = Augmenter(transformation=BackTranslation())
     s = "What on earth are you doing?"
     augmented_text_list = augmenter.augment(s)
     augmented_s = "What the hell are you doing?"

--- a/tests/test_augment_api.py
+++ b/tests/test_augment_api.py
@@ -92,9 +92,10 @@ def test_deletion_augmenter():
     augmented_s = "United States"
     assert augmented_s in augmented_text_list
 
+
 def test_back_translation():
-    from textattack.transformations.sentence_transformations import BackTranslation
     from textattack.augmentation import Augmenter
+    from textattack.transformations.sentence_transformations import BackTranslation
 
     augmenter = Augmenter(transformation=BackTranslation, transformations_per_example=1)
     s = "What on earth are you doing?"

--- a/tests/test_augment_api.py
+++ b/tests/test_augment_api.py
@@ -96,8 +96,8 @@ def test_deletion_augmenter():
 def test_back_translation():
     from textattack.augmentation import Augmenter
     from textattack.transformations.sentence_transformations import BackTranslation
-
-    augmenter = Augmenter(transformation=BackTranslation, transformations_per_example=1)
+    transformation = BackTranslation
+    augmenter = Augmenter(transformation=transformation)
     s = "What on earth are you doing?"
     augmented_text_list = augmenter.augment(s)
     augmented_s = "What the hell are you doing?"

--- a/tests/test_augment_api.py
+++ b/tests/test_augment_api.py
@@ -96,6 +96,7 @@ def test_deletion_augmenter():
 def test_back_translation():
     from textattack.augmentation import Augmenter
     from textattack.transformations.sentence_transformations import BackTranslation
+
     transformation = BackTranslation
     augmenter = Augmenter(transformation=transformation)
     s = "What on earth are you doing?"

--- a/tests/test_augment_api.py
+++ b/tests/test_augment_api.py
@@ -91,3 +91,13 @@ def test_deletion_augmenter():
     augmented_text_list = augmenter.augment(s)
     augmented_s = "United States"
     assert augmented_s in augmented_text_list
+
+def test_back_translation():
+    from textattack.transformations.sentence_transformations import BackTranslation
+    from textattack.augmentation import Augmenter
+
+    augmenter = Augmenter(transformation=BackTranslation, transformations_per_example=1)
+    s = "What on earth are you doing?"
+    augmented_text_list = augmenter.augment(s)
+    augmented_s = "What the hell are you doing?"
+    assert augmented_s in augmented_text_list

--- a/textattack/transformations/sentence_transformations/back_translation.py
+++ b/textattack/transformations/sentence_transformations/back_translation.py
@@ -24,11 +24,11 @@ class BackTranslation(SentenceTransformation):
     Example::
 
         >>> from textattack.transformations.sentence_transformations import BackTranslation
-        >>> from textattack.constraints.pre_transformation import RepeatModification, StopWordModification
+        >>> from textattack.constraints.pre_transformation import RepeatModification, StopwordModification
         >>> from textattack.augmentation import Augmenter
 
         >>> transformation = BackTranslation
-        >>> constraints = [RepeatModification(), StopWordModification()]
+        >>> constraints = [RepeatModification(), StopwordModification()]
         >>> augmenter = Augmenter(transformation = transformation, constraints = constraints)
         >>> s = 'What on earth are you doing here.'
 

--- a/textattack/transformations/sentence_transformations/back_translation.py
+++ b/textattack/transformations/sentence_transformations/back_translation.py
@@ -33,7 +33,6 @@ class BackTranslation(SentenceTransformation):
         >>> s = 'What on earth are you doing here.'
 
         >>> augmenter.augment(s)
-
     """
 
     def __init__(

--- a/textattack/transformations/sentence_transformations/back_translation.py
+++ b/textattack/transformations/sentence_transformations/back_translation.py
@@ -20,6 +20,20 @@ class BackTranslation(SentenceTransformation):
     src_model: translation model from huggingface that translates from source language to target language
     target_model: translation model from huggingface that translates from target language to source language
     chained_back_translation: run back translation in a chain for more perturbation (for example, en-es-en-fr-en)
+
+    Example::
+
+        >>> from textattack.transformations.sentence_transformations import BackTranslation
+        >>> from textattack.constraints.pre_transformation import RepeatModification, StopWordModification
+        >>> from textattack.augmentation import Augmenter
+
+        >>> transformation = BackTranslation
+        >>> constraints = [RepeatModification(), StopWordModification()]
+        >>> augmenter = Augmenter(transformation = transformation, constraints = constraints)
+        >>> s = 'What on earth are you doing here.'
+
+        >>> augmenter.augment(s)
+
     """
 
     def __init__(


### PR DESCRIPTION
Added API docstrings for back translation.

Also provides a temporary fix to pytest caused by a known issue from tensorflow.
the issue can be seen here
https://github.com/huggingface/transformers/issues/14265
https://github.com/huggingface/transformers/issues/14266
to solve the issue tensorflow 2.5.0 is installed instead of 2.6.0

Also added test for back translation.