### PR TITLE
Fixed the pytest assertion error

### DIFF
--- a/tests/test_command_line/test_attack.py
+++ b/tests/test_command_line/test_attack.py
@@ -197,6 +197,6 @@ def test_command_line_attack(name, command, sample_output_file):
 
     if DEBUG and not re.match(desired_re, stdout, flags=re.S):
         pdb.set_trace()
-    assert re.match(desired_re, stdout, flags=re.S)
+    assert re.match(desired_re, stdout, flags=re.S) is not None
 
     assert result.returncode == 0, "return code not 0"


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR addresses the assertion error which was happening in #534 in this run: https://github.com/QData/TextAttack/runs/3915172216. The main problem was that there was an assertion error that kept happening for the test_command_line_attack function because the statement did not assert anything about the regex value, so when the statement "assert re.match(desired_re, stdout, flags=re.S)" was run, it ran into an error because the AssertionError is thrown whenever frames are not equal to each other.

## Additions
- Added "assert re.match(desired_re, stdout, flags=re.S) is not None"

## Changes
- Changed the statement to "assert re.match(desired_re, stdout, flags=re.S) is not None"

## Deletions
-  Deleted "assert re.match(desired_re, stdout, flags=re.S)"

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [ ] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
