### PR TITLE
Fix CLARE StopIteration Bug

### DIFF
--- a/textattack/transformations/word_insertions/word_insertion_masked_lm.py
+++ b/textattack/transformations/word_insertions/word_insertion_masked_lm.py
@@ -2,7 +2,7 @@
 WordInsertionMaskedLM Class
 -------------------------------
 """
-
+import re
 
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
@@ -162,7 +162,7 @@ class WordInsertionMaskedLM(WordInsertion):
             word_at_index = current_text.words[index_to_modify]
             for word in new_words[i]:
                 word = word.strip("Ġ")
-                if word != word_at_index:
+                if word != word_at_index and re.search("[a-zA-Z]", word):
                     transformed_texts.append(
                         current_text.insert_text_before_word_index(
                             index_to_modify, word

--- a/textattack/transformations/word_merges/word_merge_masked_lm.py
+++ b/textattack/transformations/word_merges/word_merge_masked_lm.py
@@ -3,6 +3,7 @@ WordMergeMaskedLM class
 ------------------------------------------------
 
 """
+import re
 
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
@@ -169,7 +170,7 @@ class WordMergeMaskedLM(Transformation):
             word_at_index = current_text.words[index_to_modify]
             for word in merged_words[i]:
                 word = word.strip("Ġ")
-                if word != word_at_index:
+                if word != word_at_index and re.search("[a-zA-Z]", word):
                     temp_text = current_text.delete_word_at_index(index_to_modify + 1)
                     transformed_texts.append(
                         temp_text.replace_word_at_index(index_to_modify, word)

--- a/textattack/transformations/word_swaps/word_swap_masked_lm.py
+++ b/textattack/transformations/word_swaps/word_swap_masked_lm.py
@@ -5,6 +5,7 @@ Word Swap by BERT-Masked LM.
 
 
 import itertools
+import re
 
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
@@ -290,7 +291,11 @@ class WordSwapMaskedLM(WordSwap):
                 word_at_index = current_text.words[index_to_modify]
                 for word in replacement_words[i]:
                     word = word.strip("Ġ")
-                    if word != word_at_index and len(utils.words_from_text(word)) == 1:
+                    if (
+                        word != word_at_index
+                        and re.search("[a-zA-Z]", word)
+                        and len(utils.words_from_text(word)) == 1
+                    ):
                         transformed_texts.append(
                             current_text.replace_word_at_index(index_to_modify, word)
                         )


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR is created to fix #589, in which the sentence encoder raises StopIteration when the `newly_modified_indices` of the attacked text is an empty set. This happens when the new words swapped/inserted/merged by the CLARE transformations do not contain any letters. Our current implementation keeps tracks of `newly_modified_indices` only when the new words at the modified indices are actually words, not symbols. An example is shown below:

Suppose we have the sentence 

> lovingly photographed in the manner of a golden book sprung to life , stuart little 2 manages sweetness largely without stickiness.

and apply [WordMergeMaskedLM](https://github.com/QData/TextAttack/blob/master/textattack/transformations/word_merges/word_merge_masked_lm.py) to the sentence, one of the transformations it returns is 

> lovingly photographed in the manner of a golden book sprung to life , stuart little 2), largely without stickiness .

in which the phrase **_manages sweetness_** is changed to the symbols ),

This change will not be present in the `newly_modified_indices ` of the transformed sentence, since we omit symbols. But when running the[ sentence encoder](https://github.com/QData/TextAttack/blob/a0ec175fb3a94fdd25f8c10d3e4b29a7f6547a52/textattack/constraints/semantics/sentence_encoders/sentence_encoder.py#L136), `newly_modified_indices ` of the transformed sentence needs to have at least one element in it. The StopIteration bug consequently occurs.

To fix the issue, one thing we could do is to change how `newly_modified_indices` is recorded. This is linked to the deletion index issue as well #558. This will likely be a big change to make considering our current implementation relies on not counting symbols as modifications. The other thing we could do as a temporary fix is for the CLARE transformations is to only include transformations whose substituted/added words contain at least 1 letter. In this way, the modified indices will be recorded as normal.


## Additions

Check replacement words before making the transformation. If the replacement words do not contain any letter, skip that transformation.

