### PR TITLE
Only initialize counterfitted_GLOVE_embedding when needed, massively decreasing ram usage

### DIFF
--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -20,8 +20,10 @@ class ThoughtVector(SentenceEncoder):
     """
 
     def __init__(
-        self, embedding=WordEmbedding.counterfitted_GLOVE_embedding(), **kwargs
+        self, embedding=None, **kwargs
     ):
+        if embedding is None:
+            embedding = WordEmbedding.counterfitted_GLOVE_embedding()
         if not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(
                 "`embedding` object must be of type `textattack.shared.AbstractWordEmbedding`."

--- a/textattack/constraints/semantics/sentence_encoders/thought_vector.py
+++ b/textattack/constraints/semantics/sentence_encoders/thought_vector.py
@@ -19,9 +19,7 @@ class ThoughtVector(SentenceEncoder):
         word_embedding (textattack.shared.AbstractWordEmbedding): The word embedding to use
     """
 
-    def __init__(
-        self, embedding=None, **kwargs
-    ):
+    def __init__(self, embedding=None, **kwargs):
         if embedding is None:
             embedding = WordEmbedding.counterfitted_GLOVE_embedding()
         if not isinstance(embedding, AbstractWordEmbedding):

--- a/textattack/constraints/semantics/word_embedding_distance.py
+++ b/textattack/constraints/semantics/word_embedding_distance.py
@@ -24,7 +24,7 @@ class WordEmbeddingDistance(Constraint):
 
     def __init__(
         self,
-        embedding=WordEmbedding.counterfitted_GLOVE_embedding(),
+        embedding=None,
         include_unknown_words=True,
         min_cos_sim=None,
         max_mse_dist=None,
@@ -32,6 +32,8 @@ class WordEmbeddingDistance(Constraint):
         compare_against_original=True,
     ):
         super().__init__(compare_against_original)
+        if embedding is None:
+            embedding = WordEmbedding.counterfitted_GLOVE_embedding()
         self.include_unknown_words = include_unknown_words
         self.cased = cased
 

--- a/textattack/transformations/word_swaps/word_swap_embedding.py
+++ b/textattack/transformations/word_swaps/word_swap_embedding.py
@@ -31,10 +31,12 @@ class WordSwapEmbedding(WordSwap):
     def __init__(
         self,
         max_candidates=15,
-        embedding=WordEmbedding.counterfitted_GLOVE_embedding(),
+        embedding=None,
         **kwargs
     ):
         super().__init__(**kwargs)
+        if embedding is None:
+            embedding = WordEmbedding.counterfitted_GLOVE_embedding()
         self.max_candidates = max_candidates
         if not isinstance(embedding, AbstractWordEmbedding):
             raise ValueError(

--- a/textattack/transformations/word_swaps/word_swap_embedding.py
+++ b/textattack/transformations/word_swaps/word_swap_embedding.py
@@ -28,12 +28,7 @@ class WordSwapEmbedding(WordSwap):
     >>> augmenter.augment(s)
     """
 
-    def __init__(
-        self,
-        max_candidates=15,
-        embedding=None,
-        **kwargs
-    ):
+    def __init__(self, max_candidates=15, embedding=None, **kwargs):
         super().__init__(**kwargs)
         if embedding is None:
             embedding = WordEmbedding.counterfitted_GLOVE_embedding()


### PR DESCRIPTION

# What does this PR do?

## Summary
By only instanciating the `counterfitted_GLOVE_embedding` when
necessary, the ram usage decreases by at least two gigabytes and the startup time decreases massively.


## Changes
- `WordSwapEmbedding`, `WordEmbeddingDistance` and `ThoughtVector` only initialize `WordEmbedding.counterfitted_GLOVE_embedding`  upon initialization, not upon python parsing the files containing the class definitions. Initializing `counterfitted_GLOVE_embedding` means
  - downloading large chunks of data on initial use
  - loading a lot of data into ram, no matter whether it is ever used.


## Checklist
- [ x ] The title of your pull request should be a summary of its contribution.
- [ x ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [ x ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [ x ] To indicate a work in progress please mark it as a draft on Github.
- [ x ] Make sure existing tests pass.
- [ x ] Add relevant tests. No quality testing = no merge.
- [ x ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
