### PR TITLE
Added fix for extra quotation marks without temporary file

### DIFF
--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -146,7 +146,9 @@ class AugmentCommand(TextAttackCommand):
             rows = [
                 row
                 for row in csv.DictReader(
-                    csv_file, dialect=dialect, skipinitialspace=True,
+                    csv_file,
+                    dialect=dialect,
+                    skipinitialspace=True,
                 )
             ]
             # Validate input column.
@@ -178,7 +180,10 @@ class AugmentCommand(TextAttackCommand):
             # Print to file.
             with open(args.output_csv, "w") as outfile:
                 csv_writer = csv.writer(
-                    outfile, delimiter=",", quotechar="'", quoting=csv.QUOTE_MINIMAL,
+                    outfile,
+                    delimiter=",",
+                    quotechar="'",
+                    quoting=csv.QUOTE_MINIMAL,
                 )
                 # Write header.
                 csv_writer.writerow(output_rows[0].keys())

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -154,7 +154,9 @@ class AugmentCommand(TextAttackCommand):
                                 + row[cutoff.end() + 1 :].replace(",", "$")
                             )
                         else:
-                            row = row.replace(",", "$")
+                            end = row.rfind('"')
+                            print(row, end)
+                            row = row[:end].replace(",", "$") + row[end:]
                     row = row.replace('"', '/"')
                     yield row
 
@@ -168,7 +170,7 @@ class AugmentCommand(TextAttackCommand):
                     skipinitialspace=True,
                 )
             ]
-
+            print(rows)
             # replace markings with quotations and commas
             for row in rows:
                 for item in row:
@@ -185,7 +187,7 @@ class AugmentCommand(TextAttackCommand):
                                 row[item] = row[item][:i] + '"' + row[item][i + 1 :]
                         i += 1
                     i = 0
-
+            print(rows)
             # Validate input column.
             row_keys = set(rows[0].keys())
             if args.input_column not in row_keys:

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -178,12 +178,12 @@ class AugmentCommand(TextAttackCommand):
                     augmented_row[args.input_column] = augmentation
                     output_rows.append(augmented_row)
             # Print to file.
+            dialect.quotechar = "\\"
             with open(args.output_csv, "w") as outfile:
                 csv_writer = csv.writer(
                     outfile,
-                    delimiter=",",
-                    quotechar="'",
-                    quoting=csv.QUOTE_MINIMAL,
+                    dialect=dialect,
+                    escapechar="\\"
                 )
                 # Write header.
                 csv_writer.writerow(output_rows[0].keys())

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -141,9 +141,13 @@ class AugmentCommand(TextAttackCommand):
             # try and automatically infer the correct CSV format.
             csv_file = open(args.input_csv, "r")
 
-            def fixlines(lines):
+            def markQuotes(lines):
                 for row in lines:
-                    row = row.replace('"', "'")
+                    if '"' in row:
+                        first = row.find('"')
+                        last = row.rfind('"')
+                        row = row[:first + 1] + row[first + 1:last].replace(",", "$") + row[last:]
+                    row = row.replace('"', '/"')
                     yield row
 
             dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters=";,")
@@ -151,12 +155,22 @@ class AugmentCommand(TextAttackCommand):
             rows = [
                 row
                 for row in csv.DictReader(
-                    fixlines(csv_file),
+                    markQuotes(csv_file),
                     dialect=dialect,
                     skipinitialspace=True,
                 )
             ]
-            print(rows)
+            for row in rows:
+                i = 0
+                while i < len(row['text'])-1:
+                    if row['text'][i] == "$":
+                        row['text'] = row['text'][:i] + "," + row['text'][i+1:]
+                    if row['text'][i] == "/":
+                        if row['text'][i+1] == '"':
+                            row['text'] = row['text'][:i] + row['text'][i+1:]
+                        else:
+                            row['text'] = row['text'][:i] + '"' + row['text'][i+1:]
+                    i += 1
             # Validate input column.
             row_keys = set(rows[0].keys())
             if args.input_column not in row_keys:
@@ -183,12 +197,13 @@ class AugmentCommand(TextAttackCommand):
                     augmented_row = row.copy()
                     augmented_row[args.input_column] = augmentation
                     output_rows.append(augmented_row)
+
             # Print to file.
             with open(args.output_csv, "w") as outfile:
                 csv_writer = csv.writer(
                     outfile,
                     delimiter=",",
-                    quotechar='"',
+                    quotechar="/",
                     quoting=csv.QUOTE_MINIMAL
                 )
                 # Write header.
@@ -196,9 +211,17 @@ class AugmentCommand(TextAttackCommand):
                 # Write rows.
                 for row in output_rows:
                     csv_writer.writerow(row.values())
+
             textattack.shared.logger.info(
                 f"Wrote {len(output_rows)} augmentations to {args.output_csv} in {time.time() - start_time}s."
             )
+
+            with open(args.output_csv, 'r') as file:
+                data = file.readlines()
+            for i in range(len(data)):
+                data[i] = data[i].replace("/", "")
+            with open(args.output_csv, 'w') as file:
+                file.writelines(data)
 
     @staticmethod
     def register_subcommand(main_parser: ArgumentParser):

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -140,17 +140,23 @@ class AugmentCommand(TextAttackCommand):
             # Read in CSV file as a list of dictionaries. Use the CSV sniffer to
             # try and automatically infer the correct CSV format.
             csv_file = open(args.input_csv, "r")
+
+            def fixlines(lines):
+                for row in lines:
+                    row = row.replace('"', "'")
+                    yield row
+
             dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters=";,")
-            dialect.quoting = csv.QUOTE_NONE
             csv_file.seek(0)
             rows = [
                 row
                 for row in csv.DictReader(
-                    csv_file,
+                    fixlines(csv_file),
                     dialect=dialect,
                     skipinitialspace=True,
                 )
             ]
+            print(rows)
             # Validate input column.
             row_keys = set(rows[0].keys())
             if args.input_column not in row_keys:
@@ -178,12 +184,12 @@ class AugmentCommand(TextAttackCommand):
                     augmented_row[args.input_column] = augmentation
                     output_rows.append(augmented_row)
             # Print to file.
-            dialect.quotechar = "\\"
             with open(args.output_csv, "w") as outfile:
                 csv_writer = csv.writer(
                     outfile,
-                    dialect=dialect,
-                    escapechar="\\"
+                    delimiter=",",
+                    quotechar='"',
+                    quoting=csv.QUOTE_MINIMAL
                 )
                 # Write header.
                 csv_writer.writerow(output_rows[0].keys())

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -141,11 +141,12 @@ class AugmentCommand(TextAttackCommand):
             # try and automatically infer the correct CSV format.
             csv_file = open(args.input_csv, "r")
             dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters=";,")
+            dialect.quoting = csv.QUOTE_NONE
             csv_file.seek(0)
             rows = [
                 row
                 for row in csv.DictReader(
-                    csv_file, dialect=dialect, skipinitialspace=True
+                    csv_file, dialect=dialect, skipinitialspace=True,
                 )
             ]
             # Validate input column.
@@ -177,7 +178,7 @@ class AugmentCommand(TextAttackCommand):
             # Print to file.
             with open(args.output_csv, "w") as outfile:
                 csv_writer = csv.writer(
-                    outfile, delimiter=",", quotechar='"', quoting=csv.QUOTE_MINIMAL
+                    outfile, delimiter=",", quotechar="'", quoting=csv.QUOTE_MINIMAL,
                 )
                 # Write header.
                 csv_writer.writerow(output_rows[0].keys())

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -155,7 +155,6 @@ class AugmentCommand(TextAttackCommand):
                             )
                         else:
                             end = row.rfind('"')
-                            print(row, end)
                             row = row[:end].replace(",", "$") + row[end:]
                     row = row.replace('"', '/"')
                     yield row
@@ -170,7 +169,6 @@ class AugmentCommand(TextAttackCommand):
                     skipinitialspace=True,
                 )
             ]
-            print(rows)
             # replace markings with quotations and commas
             for row in rows:
                 for item in row:
@@ -187,7 +185,6 @@ class AugmentCommand(TextAttackCommand):
                                 row[item] = row[item][:i] + '"' + row[item][i + 1 :]
                         i += 1
                     i = 0
-            print(rows)
             # Validate input column.
             row_keys = set(rows[0].keys())
             if args.input_column not in row_keys:


### PR DESCRIPTION
# What does this PR do?
Fixes the bug in the Augmenter Command class where extra quotation marks are added to the output csv files. This PR avoids using any changes to the input file or having to create a temporary file

## Summary and Changes
Instead of changing how the csv reader works, an easier solution is to mark where quotes and commas occur within the text field while the data is being read into the DictReader(). Then before augmenting, commas and quotes are replaced back into the text value. This avoids the repeated quotation issue and the glitch where the first two quotes are removed by the csv reader. After the augmentation process, the output file is altered to remove any additional markings from the preprocessing.

Keep in mind that the solution only works if it is assumed that input files always have a text, label, and a third column that is to be kept intact.



