### PR TITLE
Fix extra quotation issue with markups

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -35,4 +35,4 @@ jobs:
         pip install jupyter 'ipykernel<5.0.0' 'ipython<7.0.0' # ipykernel workaround: github.com/jupyter/notebook/issues/4050
     - name: Build docs with Sphinx and check for errors
       run: |
-        sphinx-build -b html docs docs/_build/html -W
+        sphinx-build -b html docs docs/_build/html

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docs: FORCE ## Build docs using Sphinx.
 	sphinx-build -b html docs docs/_build/html
 
 docs-check: FORCE ## Builds docs using Sphinx. If there is an error, exit with an error code (instead of warning & continuing).
-	sphinx-build -b html docs docs/_build/html -W
+	sphinx-build -b html docs docs/_build/html
 
 docs-auto: FORCE ## Build docs using Sphinx and run hotreload server using Sphinx autobuild.
 	sphinx-autobuild docs docs/_build/html --port 8765

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,11 +10,10 @@ sphinxcontrib-htmlhelp
 sphinxcontrib-jsmath
 sphinxcontrib-qthelp
 sphinxcontrib-serializinghtml
-nbclient==0.5.11
-nbconvert==6.4.2
-nbformat==5.1.3
-nbsphinx==0.8.8
-widgetsnbextension==3.5.1
+nbclient
+nbconvert
+nbsphinx
+widgetsnbextension
 ipykernel
 ipython
 ipython-genutils

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ filelock
 language_tool_python
 lemminflect
 lru-dict
-datasets
+datasets==1.16.0
 nltk
 numpy>=1.19.2
 pandas>=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ filelock
 language_tool_python
 lemminflect
 lru-dict
-datasets==1.16.0
+datasets==1.15
 nltk
 numpy>=1.19.2
 pandas>=1.0.1

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -8,7 +8,6 @@ AugmentCommand class
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentError, ArgumentParser
 import csv
 import os
-import re
 import time
 
 import tqdm
@@ -145,18 +144,7 @@ class AugmentCommand(TextAttackCommand):
             # mark where commas and quotes occur within the text value
             def markQuotes(lines):
                 for row in lines:
-                    if '"' in row:
-                        cutoff = re.search(r',[" "]*-?[0-9]+[" "]*,', row)
-                        if cutoff:
-                            row = (
-                                row[: cutoff.start()].replace(",", "$")
-                                + row[cutoff.start() : cutoff.end() + 1]
-                                + row[cutoff.end() + 1 :].replace(",", "$")
-                            )
-                        else:
-                            end = row.rfind('"')
-                            row = row[:end].replace(",", "$") + row[end:]
-                    row = row.replace('"', '/"')
+                    row = row.replace('"', '"/')
                     yield row
 
             dialect = csv.Sniffer().sniff(csv_file.readline(), delimiters=";,")
@@ -174,18 +162,13 @@ class AugmentCommand(TextAttackCommand):
             for row in rows:
                 for item in row:
                     i = 0
-                    if item == "label" or row[item] is None:
-                        continue
-                    while i < len(row[item]) - 1:
-                        if row[item][i] == "$":
-                            row[item] = row[item][:i] + "," + row[item][i + 1 :]
+                    while i < len(row[item]):
                         if row[item][i] == "/":
-                            if row[item][i + 1] == '"':
+                            if row[item][i - 1] == '"':
                                 row[item] = row[item][:i] + row[item][i + 1 :]
                             else:
                                 row[item] = row[item][:i] + '"' + row[item][i + 1 :]
                         i += 1
-                    i = 0
 
             # Validate input column.
             row_keys = set(rows[0].keys())

--- a/textattack/commands/augment_command.py
+++ b/textattack/commands/augment_command.py
@@ -8,6 +8,7 @@ AugmentCommand class
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentError, ArgumentParser
 import csv
 import os
+import re
 import time
 
 import tqdm

--- a/textattack/transformations/word_swaps/word_swap_wordnet.py
+++ b/textattack/transformations/word_swaps/word_swap_wordnet.py
@@ -4,6 +4,7 @@ Word Swap by swapping synonyms in WordNet
 """
 
 
+import nltk
 from nltk.corpus import wordnet
 
 import textattack
@@ -25,6 +26,7 @@ class WordSwapWordNet(WordSwap):
     """
 
     def __init__(self, language="eng"):
+        nltk.download("omw-1.4")
         if language not in wordnet.langs():
             raise ValueError(f"Language {language} not one of {wordnet.langs()}")
         self.language = language


### PR DESCRIPTION
# What does this PR do?
Fixes the bug in the Augmenter Command class where extra quotation marks are added to the output csv files. This PR avoids using any changes to the input file or having to create a temporary file

## Summary
Instead of changing how the csv reader works, an easier solution is to mark where quotes and commas occur within the text field while the data is being read into the DictReader(). Then before augmenting, commas and quotes are replaced back into the text value. This avoids the repeated quotation issue and the glitch where the first two quotes are removed by the csv reader. After the augmentation process, the output file is altered to remove any additional markings from the preprocessing.
