### PR TITLE
Add ReprMixin for more easy enhancement for the __repr__ and __str__ methods of a class

### DIFF
--- a/textattack/constraints/constraint.py
+++ b/textattack/constraints/constraint.py
@@ -7,10 +7,10 @@ TextAttack Constraint Class
 from abc import ABC, abstractmethod
 
 import textattack
-from textattack.shared.utils import default_class_repr
+from textattack.shared.utils import ReprMixin
 
 
-class Constraint(ABC):
+class Constraint(ReprMixin, ABC):
     """An abstract class that represents constraints on adversial text
     examples. Constraints evaluate whether transformations from a
     ``AttackedText`` to another ``AttackedText`` meet certain conditions.
@@ -123,5 +123,3 @@ class Constraint(ABC):
         line strings are acceptable.
         """
         return ["compare_against_original"]
-
-    __str__ = __repr__ = default_class_repr

--- a/textattack/constraints/pre_transformation/max_word_index_modification.py
+++ b/textattack/constraints/pre_transformation/max_word_index_modification.py
@@ -6,8 +6,6 @@ Max Word Index Modification
 """
 from textattack.constraints import PreTransformationConstraint
 
-# from textattack.shared.utils import default_class_repr
-
 
 class MaxWordIndexModification(PreTransformationConstraint):
     """A constraint disallowing the modification of words which are past some

--- a/textattack/constraints/pre_transformation/repeat_modification.py
+++ b/textattack/constraints/pre_transformation/repeat_modification.py
@@ -6,8 +6,6 @@ Repeat Modification
 
 from textattack.constraints import PreTransformationConstraint
 
-# from textattack.shared.utils import default_class_repr
-
 
 class RepeatModification(PreTransformationConstraint):
     """A constraint disallowing the modification of words which have already

--- a/textattack/constraints/pre_transformation_constraint.py
+++ b/textattack/constraints/pre_transformation_constraint.py
@@ -5,10 +5,10 @@ Pre-Transformation Constraint Class
 
 from abc import ABC, abstractmethod
 
-from textattack.shared.utils import default_class_repr
+from textattack.shared.utils import ReprMixin
 
 
-class PreTransformationConstraint(ABC):
+class PreTransformationConstraint(ReprMixin, ABC):
     """An abstract class that represents constraints which are applied before
     the transformation.
 
@@ -62,5 +62,3 @@ class PreTransformationConstraint(ABC):
         line strings are acceptable.
         """
         return []
-
-    __str__ = __repr__ = default_class_repr

--- a/textattack/goal_functions/goal_function.py
+++ b/textattack/goal_functions/goal_function.py
@@ -15,10 +15,10 @@ from textattack.goal_function_results.goal_function_result import (
     GoalFunctionResultStatus,
 )
 from textattack.shared import validators
-from textattack.shared.utils import default_class_repr
+from textattack.shared.utils import ReprMixin
 
 
-class GoalFunction(ABC):
+class GoalFunction(ReprMixin, ABC):
     """Evaluates how well a perturbed attacked_text object is achieving a
     specified goal.
 
@@ -237,5 +237,3 @@ class GoalFunction(ABC):
         self.__dict__ = state
         if self.use_cache:
             self._call_model_cache = lru.LRU(state["_call_model_cache"])
-
-    __repr__ = __str__ = default_class_repr

--- a/textattack/search_methods/search_method.py
+++ b/textattack/search_methods/search_method.py
@@ -6,10 +6,10 @@ Search Method Abstract Class
 
 from abc import ABC, abstractmethod
 
-from textattack.shared.utils import default_class_repr
+from textattack.shared.utils import ReprMixin
 
 
-class SearchMethod(ABC):
+class SearchMethod(ReprMixin, ABC):
     """This is an abstract class that contains main helper functionality for
     search methods.
 
@@ -65,8 +65,3 @@ class SearchMethod(ABC):
             )
         else:
             return self.goal_function.model
-
-    def extra_repr_keys(self):
-        return []
-
-    __repr__ = __str__ = default_class_repr

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -108,6 +108,20 @@ def default_class_repr(self):
     return f"{self.__class__.__name__}{extra_str}"
 
 
+class ReprMixin(object):
+    """ Mixin for enhanced __repr__ and __str__. """
+
+    def __repr__(self):
+        return default_class_repr(self)
+
+    __str__ = __repr__
+
+    def extra_repr_keys(self):
+        """
+        """
+        return []
+
+
 LABEL_COLORS = [
     "red",
     "green",

--- a/textattack/shared/word_embeddings.py
+++ b/textattack/shared/word_embeddings.py
@@ -14,7 +14,7 @@ import torch
 from textattack.shared import utils
 
 
-class AbstractWordEmbedding(ABC):
+class AbstractWordEmbedding(utils.ReprMixin, ABC):
     """Abstract class representing word embedding used by TextAttack.
 
     This class specifies all the methods that is required to be defined
@@ -96,8 +96,6 @@ class AbstractWordEmbedding(ABC):
             neighbours (list[int]): List of indices of the nearest neighbours
         """
         raise NotImplementedError()
-
-    __repr__ = __str__ = utils.default_class_repr
 
 
 class WordEmbedding(AbstractWordEmbedding):

--- a/textattack/transformations/transformation.py
+++ b/textattack/transformations/transformation.py
@@ -6,10 +6,10 @@ Transformation Abstract Class
 
 from abc import ABC, abstractmethod
 
-from textattack.shared.utils import default_class_repr
+from textattack.shared.utils import ReprMixin
 
 
-class Transformation(ABC):
+class Transformation(ReprMixin, ABC):
     """An abstract class for transforming a sequence of text to produce a
     potential adversarial example."""
 
@@ -67,8 +67,3 @@ class Transformation(ABC):
     @property
     def deterministic(self):
         return True
-
-    def extra_repr_keys(self):
-        return []
-
-    __repr__ = __str__ = default_class_repr


### PR DESCRIPTION
# What does this PR do?

Adds `ReprMixin` for more easy enhancement for the `__repr__` and `__str__` methods of a class so that one does not have to write
```python
    def extra_repr_keys(self):
        return []

    __repr__ = __str__ = default_class_repr
```
inside a class. Instead, one just need to use `ReprMixin` as a base class. For example,
```python
class Constraint(ReprMixin, ABC):
```

## Summary
This PR adds adds `ReprMixin` in `textattack.shared.utils.strings` for more easy enhancement for the `__repr__` and `__str__` methods of a class.

## Additions
Added `ReprMixin` in `textattack.shared.utils.strings`

## Changes
Each class that uses the method `default_class_repr` from `textattack.shared.utils.strings` now inherits `ReprMixin` as a base class
.
## Deletions
Code like
```python
    def extra_repr_keys(self):
        return []

    __repr__ = __str__ = default_class_repr
```
are removed from those who use `ReprMixin` as a base class.

## Checklist
- [  ] The title of your pull request should be a summary of its contribution.
- [  ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
