### PR TITLE
Fix black issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ format: FORCE  ## Run black and isort (rewriting files)
 	docformatter --in-place --recursive textattack tests
 
 lint: FORCE  ## Run black, isort, flake8 (in check mode)
-    pip install black>=22.3.0
 	black . --check
 	isort --check-only tests textattack
 	flake8 . --count --ignore=$(PEP_IGNORE_ERRORS) --show-source --statistics --exclude=./.*,build,dist

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ format: FORCE  ## Run black and isort (rewriting files)
 	docformatter --in-place --recursive textattack tests
 
 lint: FORCE  ## Run black, isort, flake8 (in check mode)
+    pip install black>=22.3.0
 	black . --check
 	isort --check-only tests textattack
 	flake8 . --count --ignore=$(PEP_IGNORE_ERRORS) --show-source --statistics --exclude=./.*,build,dist

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ pinyin==0.4.0
 jieba
 OpenHowNet
 pycld2
+black>=22.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,4 +22,4 @@ pinyin==0.4.0
 jieba
 OpenHowNet
 pycld2
-black>=22.3.0
+click<8.1.0


### PR DESCRIPTION
# What does this PR do?

## Summary
Fix black dependency issue. Package `pycld2` requires `black` 20.8b1, which does not work with the latest version of `click`. The version of `click` cannot exceed 8.1.0.