### PR TITLE
enhance functions words_from_text and has_letter in strings.py using regular expression

### DIFF
--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -4,7 +4,7 @@ import pytest
 
 try:
     import textattack
-except:
+except ModuleNotFoundError:
     # one can do test locally without installing textattack
     import pathlib
     import sys

--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -6,7 +6,8 @@ try:
     import textattack
 except:
     # one can do test locally without installing textattack
-    import sys, pathlib
+    import pathlib
+    import sys
 
     sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.resolve()))
     import textattack

--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -2,7 +2,15 @@ import collections
 
 import pytest
 
-import textattack
+try:
+    import textattack
+except:
+    # one can do test locally without installing textattack
+    import sys, pathlib
+
+    sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.resolve()))
+    import textattack
+
 
 raw_text = "A person walks up stairs into a room and sees beer poured from a keg and people talking."
 

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -43,10 +43,10 @@ def words_from_text(s, words_to_ignore=[]):
 
     homos = """˗৭Ȣ𝟕бƼᏎƷᒿlO`ɑЬϲԁе𝚏ɡհіϳ𝒌ⅼｍոорԛⲅѕ𝚝սѵԝ×уᴢ"""
     exceptions = """'-_*@"""
-    filter_pattern = homos + """'\-_\*@"""
+    filter_pattern = homos + """'\\-_\\*@"""
     # TODO: consider whether one should add "." to `exceptions` (and "\." to `filter_pattern`)
     # example "My email address is xxx@yyy.com"
-    filter_pattern = f"[\w{filter_pattern}]+"
+    filter_pattern = f"[\\w{filter_pattern}]+"
     words = []
     for word in s.split():
         # Allow apostrophes, hyphens, underscores, asterisks and at signs as long as they don't begin the word.

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -1,4 +1,4 @@
-import string
+import string, re
 
 import jieba
 import pycld2 as cld2
@@ -8,11 +8,7 @@ from .importing import LazyLoader
 
 def has_letter(word):
     """Returns true if `word` contains at least one character in [A-Za-z]."""
-    # TODO implement w regex
-    for c in word:
-        if c.isalpha():
-            return True
-    return False
+    return re.search("[A-Za-z]+", word) is not None
 
 
 def is_one_word(word):
@@ -32,54 +28,8 @@ def add_indent(s_, numSpaces):
 
 
 def words_from_text(s, words_to_ignore=[]):
-    homos = set(
-        [
-            "˗",
-            "৭",
-            "Ȣ",
-            "𝟕",
-            "б",
-            "Ƽ",
-            "Ꮞ",
-            "Ʒ",
-            "ᒿ",
-            "l",
-            "O",
-            "`",
-            "ɑ",
-            "Ь",
-            "ϲ",
-            "ԁ",
-            "е",
-            "𝚏",
-            "ɡ",
-            "հ",
-            "і",
-            "ϳ",
-            "𝒌",
-            "ⅼ",
-            "ｍ",
-            "ո",
-            "о",
-            "р",
-            "ԛ",
-            "ⲅ",
-            "ѕ",
-            "𝚝",
-            "ս",
-            "ѵ",
-            "ԝ",
-            "×",
-            "у",
-            "ᴢ",
-        ]
-    )
     """Lowercases a string, removes all non-alphanumeric characters, and splits
     into words."""
-    # TODO implement w regex
-    words = []
-    word = ""
-
     try:
         isReliable, textBytesFound, details = cld2.detect(s)
         if details[0][0] == "Chinese" or details[0][0] == "ChineseT":
@@ -90,19 +40,19 @@ def words_from_text(s, words_to_ignore=[]):
     except Exception:
         s = " ".join(s.split())
 
-    for c in s:
-        if c.isalnum() or c in homos:
-            word += c
-        elif c in "'-_*@" and len(word) > 0:
-            # Allow apostrophes, hyphens, underscores, asterisks and at signs as long as they don't begin the
-            # word.
-            word += c
-        elif word:
-            if word not in words_to_ignore:
-                words.append(word)
-            word = ""
-    if len(word) and (word not in words_to_ignore):
-        words.append(word)
+    homos = """˗৭Ȣ𝟕бƼᏎƷᒿlO`ɑЬϲԁе𝚏ɡհіϳ𝒌ⅼｍոорԛⲅѕ𝚝սѵԝ×уᴢ"""
+    exceptions = """'-_*@"""
+    filter_pattern = homos + """'\-_\*@"""
+    # TODO: consider whether one should add "." to `exceptions` (and "\." to `filter_pattern`)
+    # example "My email address is xxx@yyy.com"
+    filter_pattern = f"[\w{filter_pattern}]+"
+    words = []
+    for word in s.split():
+        # Allow apostrophes, hyphens, underscores, asterisks and at signs as long as they don't begin the word.
+        word = word.lstrip(exceptions)
+        filt = [w.lstrip(exceptions) for w in re.findall(filter_pattern, word)]
+        words.extend(filt)
+    words = list(filter(lambda w: w not in words_to_ignore + [""], words))
     return words
 
 

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -1,4 +1,5 @@
-import string, re
+import re
+import string
 
 import jieba
 import pycld2 as cld2


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR re-implements the functions `has_letter` and `words_from_text` in `textattack.shared.utils.strings.py` using Python's built-in regular expression module `re`.

## Additions
NA

## Changes
- Implementation of `has_letter` and `words_from_text` in `textattack.shared.utils.strings.py` now uses methods including `re.search`, `re.findall`, etc. from Python's built-in regular expression module `re`, in place of `str`'s methods `isalpha`, `isalnum`.

## Deletions
NA

## Checklist
- [  ] The title of your pull request should be a summary of its contribution.
- [  ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'

## By the way
- the original `words_from_text` is able to correctly handle the examples given in PR #487, maybe my master branch is out-of-date. I'm not able to find the cells in my test Jupiter notebook. Maybe I've deleted these cells.
- for using regular expression, most items in `homos` seems redundant (useless)
 ```python
>>> import re
>>> homos = """˗৭Ȣ𝟕бƼᏎƷᒿlO`ɑЬϲԁе𝚏ɡհіϳ𝒌ⅼｍոорԛⲅѕ𝚝սѵԝ×уᴢ"""
>>> re.findall("[\w]+", homos)
['৭Ȣ𝟕бƼᏎƷᒿlO', 'ɑЬϲԁе𝚏ɡհіϳ𝒌ⅼｍոорԛⲅѕ𝚝սѵԝ', 'уᴢ']
```
i.e. `re` (the same for `str.isalnum`) already regards most items in `homos` as "word characters".
