### PR TITLE
Add TokenizerWrapper for Flair Sentence Call

### DIFF
--- a/textattack/constraints/grammaticality/part_of_speech.py
+++ b/textattack/constraints/grammaticality/part_of_speech.py
@@ -5,6 +5,10 @@ Part of Speech Constraint
 import flair
 from flair.data import Sentence
 from flair.models import SequenceTagger
+
+# To wrap function textattack.shared.utils.words_from_text as a
+# Tokenizer while calling Sentence from flair
+from flair.tokenization import TokenizerWrapper
 import lru
 import nltk
 
@@ -56,7 +60,7 @@ class PartOfSpeech(Constraint):
         self.language_nltk = language_nltk
         self.language_stanza = language_stanza
 
-        self._pos_tag_cache = lru.LRU(2 ** 14)
+        self._pos_tag_cache = lru.LRU(2**14)
         if tagger_type == "flair":
             if tagset == "universal":
                 self._flair_pos_tagger = SequenceTagger.load("upos-fast")
@@ -93,7 +97,10 @@ class PartOfSpeech(Constraint):
 
             if self.tagger_type == "flair":
                 context_key_sentence = Sentence(
-                    context_key, use_tokenizer=textattack.shared.utils.words_from_text
+                    context_key,
+                    use_tokenizer=TokenizerWrapper(
+                        textattack.shared.utils.words_from_text
+                    ),
                 )
                 self._flair_pos_tagger.predict(context_key_sentence)
                 word_list, pos_list = textattack.shared.utils.zip_flair_result(

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -11,6 +11,10 @@ import math
 
 import flair
 from flair.data import Sentence
+
+# To wrap function textattack.shared.utils.words_from_text as a
+# Tokenizer while calling Sentence from flair
+from flair.tokenization import TokenizerWrapper
 import numpy as np
 import torch
 
@@ -138,7 +142,8 @@ class AttackedText:
         """
         if not self._pos_tags:
             sentence = Sentence(
-                self.text, use_tokenizer=textattack.shared.utils.words_from_text
+                self.text,
+                use_tokenizer=TokenizerWrapper(textattack.shared.utils.words_from_text),
             )
             textattack.shared.utils.flair_tag(sentence)
             self._pos_tags = sentence
@@ -168,7 +173,8 @@ class AttackedText:
         """
         if not self._ner_tags:
             sentence = Sentence(
-                self.text, use_tokenizer=textattack.shared.utils.words_from_text
+                self.text,
+                use_tokenizer=TokenizerWrapper(textattack.shared.utils.words_from_text),
             )
             textattack.shared.utils.flair_tag(sentence, model_name)
             self._ner_tags = sentence

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -239,7 +239,10 @@ def flair_tag(sentence, tag_type="upos-fast"):
         from flair.models import SequenceTagger
 
         _flair_pos_tagger = SequenceTagger.load(tag_type)
-    _flair_pos_tagger.predict(sentence)
+    # Adding force_token_predictions = True , as per
+    # Flair GH-2728: add option to force token-level predictions #2750
+    # This fix is to Due to Flair:Major refactoring of internal label logic #2645
+    _flair_pos_tagger.predict(sentence, force_token_predictions=True)
 
 
 def zip_flair_result(pred, tag_type="upos-fast"):
@@ -258,7 +261,8 @@ def zip_flair_result(pred, tag_type="upos-fast"):
         if "pos" in tag_type:
             pos_list.append(token.annotation_layers["pos"][0]._value)
         elif tag_type == "ner":
-            pos_list.append(token.get_tag("ner"))
+            # get_tag no longer supported by Flair as of Flair:Major refactoring of internal label logic #2645
+            pos_list.append(token.get_label("ner"))
 
     return word_list, pos_list
 


### PR DESCRIPTION
# What does this PR do?

## Summary
*With the recent update in the Flair Package (0.11.3), the Sentence Class no longer accepts a Callable function as the tokenization method and the token object no longer supports the get_tag function, PR updates Flair Sentence Call and Token usage to integrate with the new Flair Package.*

## Additions
- *Added Import for  `TokenizerWrapper` from `flair.tokenization`.*

## Changes
- *Updated Sentence initialization for CLAREAugmenter and CheckListAugmenter.*
- *Updated `Flair` Predictor's predict call to force token-level predictions.*
- *Changed `token.get_tag` to `token.get_label` to get `ner` labels.* 

## Issues Addressed 
Fixes #642
Fixes #638

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [X] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
