### PR TITLE
Fix logging to wandb in attack args for attackresults

### DIFF
--- a/textattack/loggers/weights_and_biases_logger.py
+++ b/textattack/loggers/weights_and_biases_logger.py
@@ -13,14 +13,13 @@ class WeightsAndBiasesLogger(Logger):
     """Logs attack results to Weights & Biases."""
 
     def __init__(self, **kwargs):
-        assert "project" in kwargs
 
         global wandb
         wandb = LazyLoader("wandb", globals(), "wandb")
 
         wandb.init(**kwargs)
         self.kwargs = kwargs
-        self.project_name = kwargs["project"]
+        self.project_name = wandb.run.project_name()
         self._result_table_rows = []
 
     def __setstate__(self, state):

--- a/textattack/loggers/weights_and_biases_logger.py
+++ b/textattack/loggers/weights_and_biases_logger.py
@@ -32,6 +32,14 @@ class WeightsAndBiasesLogger(Logger):
     def log_summary_rows(self, rows, title, window_id):
         table = wandb.Table(columns=["Attack Results", ""])
         for row in rows:
+            if isinstance(row[1], str):
+                try:
+                    row[1] = row[1].replace("%", "")
+                    row[1] = float(row[1])
+                except ValueError:
+                    raise ValueError(
+                        f'Unable to convert row value "{row[1]}" for Attack Result "{row[0]}" into float'
+                    )
             table.add_data(*row)
             metric_name, metric_score = row
             wandb.run.summary[metric_name] = metric_score


### PR DESCRIPTION
# What does this PR do?
*PR fixes 2 issues seen when logging attack results to wandb*

## Summary
*Logging Attack Results Summary to wandb is currently failing with TypeError - Data row contained incompatible types. Fix involves converting string entries to float(Number) to maintain same datatype throughout the column in the table.*

*As per the documentation , we do not have not specify project name to allow wandb create a project name automatically. Removed Assertion*

## Additions
- *Added Code to convert string values in Attack Results Summary to Float for logging to wandb.*

## Changes
- *Changed method to get project_name for wandb logging* 

## Deletions
- *Deleted Assertion which is not necessary*

**Issues Addressed 
- Fixes #646 
- Fixes #645 

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [X] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
