### PR TITLE
Fix word_swap_masked_lm bug

### DIFF
--- a/textattack/transformations/word_swaps/word_swap_masked_lm.py
+++ b/textattack/transformations/word_swaps/word_swap_masked_lm.py
@@ -116,9 +116,7 @@ class WordSwapMaskedLM(WordSwap):
             masked_text = current_text.replace_word_at_index(
                 index, self._lm_tokenizer.mask_token
             )
-            # Obtain window
-            masked_text = masked_text.text_window_around_index(index, self.window_size)
-            masked_texts.append(masked_text)
+            masked_texts.append(masked_text.text)
 
         i = 0
         # 2-D list where for each index to modify we have a list of replacement words


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR fixes a bug caused by the `text_window_around_index` function in `word_swap_masked_lm`. The function omits `[` when the mask token is at the first index of the sentence, and omits `]` when the mask token is at the last index of the sentence. More details can be found in #622.

## Changes
- Convert Attacked_text to strings directly with `masked_text.text`  instead of using`text_window_around_index` 

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [x] Make sure existing tests pass.
- [x] Add relevant tests. No quality testing = no merge.
- [x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
