### PR TITLE
Fix WordCNN input embedding gradient calculation

### DIFF
--- a/textattack/models/wrappers/pytorch_model_wrapper.py
+++ b/textattack/models/wrappers/pytorch_model_wrapper.py
@@ -89,7 +89,16 @@ class PyTorchModelWrapper(ModelWrapper):
         loss.backward()
 
         # grad w.r.t to word embeddings
-        grad = torch.transpose(emb_grads[0], 0, 1)[0].cpu().numpy()
+
+        # Fix for Issue #601
+
+        # Check if gradient has shape [max_sequence,1,_] ( when model input in transpose of input sequence)
+
+        if emb_grads[0].shape[1] == 1:
+            grad = torch.transpose(emb_grads[0], 0, 1)[0].cpu().numpy()
+        else:
+            # gradient has shape [1,max_sequence,_]
+            grad = emb_grads[0][0].cpu().numpy()
 
         embedding_layer.weight.requires_grad = original_state
         emb_hook.remove()


### PR DESCRIPTION
# What does this PR do?
PR fixes gradient calculation for WordCNN  in `get_grad` function in `textattack/models/wrappers/pytorch_model_wrapper.py` .

## Summary
*get_grad function currently calculates gradients irrespective of the inputs to the model. In models for which the inputs are not
transposed , the gradient is calculated incorrectly leading to errors in functions such as gradient_based word importance ranking used in A2T recipe.*

*get_grad changed to correctly calculate grad with appropriate tensor shape with respective to gradient genereated by the auto differentiation hook*

## Additions

## Changes
- *Changed `get_grad` function in `pytorch_model_wrapper.py` to include checks for Models with non-transposed inputs*

## Deletions

## Issues Addressed 
- Fixes #601 

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [X] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
