### PR TITLE
Fix Querybudget related IndexError in PWWS Attack

### DIFF
--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -73,13 +73,21 @@ class GreedyWordSwapWIR(SearchMethod):
                     # no valid synonym substitutions for this word
                     delta_ps.append(0.0)
                     continue
-                swap_results, _ = self.get_goal_results(transformed_text_candidates)
+                swap_results, search_over = self.get_goal_results(
+                    transformed_text_candidates
+                )
                 score_change = [result.score for result in swap_results]
                 if not score_change:
                     delta_ps.append(0.0)
                     continue
                 max_score_change = np.max(score_change)
                 delta_ps.append(max_score_change)
+
+                # Exit Loop when search_over is True - but we need to make sure delta_ps
+                # is the same size as softmax_saliency_scores
+                if search_over:
+                    delta_ps = delta_ps + [0.0] * (len_text - len(delta_ps))
+                    break
 
             index_scores = softmax_saliency_scores * np.array(delta_ps)
 


### PR DESCRIPTION
# What does this PR do?

## Summary
*While using query-budget constraints with pwws attacks, we get an IndexError. This is due to the `search_over` flag not being updated appropriately in the `weighted-saliency` condition block in the `_get_index_order` function.*

*PR updates `search_over` flag appropriately and added code to exit loop when `search_over` is set to True*

## Additions

## Changes
- *`search_over` flag appropriately updated and used to break out of loop to avoid unnecessary get_goal_results function calls.*

## Deletions

## Issues Addressed

Fixes #437  

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [X] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
