### PR TITLE
Fix adversarial dataset generation in trainer.py

### DIFF
--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -203,18 +203,24 @@ class Trainer:
             f"Attack success rate: {success_rate:.2f}% [{attack_types['SuccessfulAttackResult']} / {total_attacks}]"
         )
         # TODO: This will produce a bug if we need to manipulate ground truth output.
+
+        # To Fix Issue #498 , We need to add the Non Output columns in one tuple to represent input columns
+        # Since adversarial_example won't be an input to the model , we will have to remove it from the input
+        # dictionary in collate_fn
         adversarial_examples = [
             (
-                tuple(r.perturbed_result.attacked_text._text_input.values()),
+                tuple(r.perturbed_result.attacked_text._text_input.values())
+                + ("adversarial_example",),
                 r.perturbed_result.ground_truth_output,
-                "adversarial_example",
             )
             for r in results
             if isinstance(r, (SuccessfulAttackResult, MaximizedAttackResult))
         ]
+
+        # Name for column indicating if an example is adversarial is set as "_example_type".
         adversarial_dataset = textattack.datasets.Dataset(
             adversarial_examples,
-            input_columns=self.train_dataset.input_columns,
+            input_columns=self.train_dataset.input_columns + ("_example_type",),
             label_map=self.train_dataset.label_map,
             label_names=self.train_dataset.label_names,
             output_scale_factor=self.train_dataset.output_scale_factor,
@@ -377,9 +383,15 @@ class Trainer:
             targets = []
             is_adv_sample = []
             for item in data:
-                if len(item) == 3:
-                    # `len(item)` is 3 for adversarial training dataset
-                    _input, label, adv = item
+                if "_example_type" in item[0].keys():
+
+                    # Get example type value from OrderedDict and remove it
+
+                    adv = item[0].pop("_example_type")
+
+                    # with _example_type removed from item[0] OrderedDict
+                    # all other keys should be part of input
+                    _input, label = item
                     if adv != "adversarial_example":
                         raise ValueError(
                             "`item` has length of 3 but last element is not for marking if the item is an `adversarial example`."


### PR DESCRIPTION
# What does this PR do?

## Summary
*As detailed in Issue #498 , the adversarial dataset generated in `_generate_adversarial_examples` function in `trainer.py` was leading to the column indicating the example-type being masked/lost.*

*Due to the masking of the column all the examples were considered as clean_examples which is not expected behaviour.*

*Commit includes changes to the data-structure of `adversarial_examples` to suit the Dataset wrapper and changes to the condition statements in `collate_fn` function in `get_train_dataloader` function.*

## Additions

## Changes
- *adversarial_examples data structure was changed to suit Dataset Wrapper from `textattack.datasets.Dataset`.*
    - *adversarial_examples data structure was initially `(tuple_containing(text) , label , "adversarial_example")`  which has been changed to `(tuple_containing(text , "adversarial_example"), label)`*
    - *Column Name containing `adversarial_example` as `_example_type`.*
    
- *Conditional statements in `collate_fn` changed under `get_train_dataloader` to follow new structure of adversarial dataset*

## Deletions

## Issues Addressed 

Fixes #498 

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [X] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
