### PR TITLE
add full range of ANSI colors for printing >3 classes

### DIFF
--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -152,9 +152,17 @@ class ANSI_ESCAPE_CODES:
     HEADER = "\033[95m"
     OKBLUE = "\033[94m"
     OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
+
     GRAY = "\033[37m"
     PURPLE = "\033[35m"
+    YELLOW = "\033[93m"
+    ORANGE = "\033[38:5:208m"
+    PINK = "\033[95m"
+    CYAN = "\033[96m"
+    GRAY = "\033[38:5:240m"
+    BROWN = "\033[38:5:52m"
+
+    WARNING = "\033[93m"
     FAIL = "\033[91m"
     BOLD = "\033[1m"
     UNDERLINE = "\033[4m"
@@ -183,8 +191,18 @@ def color_text(text, color=None, method=None):
             color = ANSI_ESCAPE_CODES.OKBLUE
         elif color == "purple":
             color = ANSI_ESCAPE_CODES.PURPLE
+        elif color == "yellow":
+            color = ANSI_ESCAPE_CODES.YELLOW
+        elif color == "orange":
+            color = ANSI_ESCAPE_CODES.ORANGE
+        elif color == "pink":
+            color = ANSI_ESCAPE_CODES.PINK
+        elif color == "cyan":
+            color = ANSI_ESCAPE_CODES.CYAN
         elif color == "gray":
             color = ANSI_ESCAPE_CODES.GRAY
+        elif color == "brown":
+            color = ANSI_ESCAPE_CODES.BROWN
         elif color == "bold":
             color = ANSI_ESCAPE_CODES.BOLD
         elif color == "underline":


### PR DESCRIPTION
# What does this PR do?

This PR adds more colors to the `color_from_output` function so that we can properly print and colorize in the terminal even with a large number of classes. Before, this worked in HTML but broke when trying to colorize label colors like "yellow" in ANSI.