### PR TITLE
Fix FutureWarning caused by pandas append method

### DIFF
--- a/textattack/loggers/csv_logger.py
+++ b/textattack/loggers/csv_logger.py
@@ -19,7 +19,7 @@ class CSVLogger(Logger):
         logger.info(f"Logging to CSV at path {filename}")
         self.filename = filename
         self.color_method = color_method
-        self.df = pd.DataFrame()
+        self.row_list = []
         self._flushed = True
 
     def log_attack_result(self, result):
@@ -38,10 +38,11 @@ class CSVLogger(Logger):
             "num_queries": result.num_queries,
             "result_type": result_type,
         }
-        self.df = self.df.append(row, ignore_index=True)
+        self.row_list.append(row)
         self._flushed = False
 
     def flush(self):
+        self.df = pd.DataFrame.from_records(self.row_list)
         self.df.to_csv(self.filename, quoting=csv.QUOTE_NONNUMERIC, index=False)
         self._flushed = True
 


### PR DESCRIPTION
# What does this PR do?

## Summary
*Using Dataframe Append method is deprecated by pandas and is not
considered good practice. Using Append method raises FutureWarning
which floods the stdout for every append call.*

*Commit uses Dataframe from_records function to achieve the same df and
creation of csv file from dataframe.*

## Additions


## Changes
- *Now using  a list to store all the row dictionaries and creating the dataframe using `pd.DataFrame.from_records` function.*

## Deletions

## Issues Addressed 
Fixes #668 

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [X] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
