### PR TITLE
Fix typo in example of BackTranslation class docstring

### DIFF
--- a/textattack/transformations/sentence_transformations/back_translation.py
+++ b/textattack/transformations/sentence_transformations/back_translation.py
@@ -34,7 +34,7 @@ class BackTranslation(SentenceTransformation):
         >>> from textattack.constraints.pre_transformation import RepeatModification, StopwordModification
         >>> from textattack.augmentation import Augmenter
 
-        >>> transformation = BackTranslation
+        >>> transformation = BackTranslation()
         >>> constraints = [RepeatModification(), StopwordModification()]
         >>> augmenter = Augmenter(transformation = transformation, constraints = constraints)
         >>> s = 'What on earth are you doing here.'


### PR DESCRIPTION
# What does this PR do?

## Summary

The example in the docstring of the [`BackTranslation`](https://textattack.readthedocs.io/en/latest/apidoc/textattack.transformations.sentence_transformations.html?highlight=backtranslation#backtranslation-class) example appears to have a typo: the `transformation` is given as `BackTranslation` (a _reference_ to the class) but should be `BackTranslation()` (an _instance_ of the class).

## Additions

- N/A

## Changes

- Correct example in docstring of `BackTranslation` class to correctly instantiate `BackTranslation()` as the `transformation`

## Deletions

- N/A

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [ ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [ ] To indicate a work in progress please mark it as a draft on Github.
- [ ] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [ ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
