### PR TITLE
Handle when saliency_scores not equal to len_text

### DIFF
--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -65,6 +65,13 @@ class GreedyWordSwapWIR(SearchMethod):
             # compute the largest change in score we can find by swapping each word
             delta_ps = []
             for idx in indices_to_order:
+                
+                # Exit Loop when search_over is True - but we need to make sure delta_ps
+                # is the same size as softmax_saliency_scores
+                if search_over:
+                    delta_ps = delta_ps + [0.0] * (len(softmax_saliency_scores) - len(delta_ps))
+                    break
+                
                 transformed_text_candidates = self.get_transformations(
                     initial_text,
                     original_text=initial_text,
@@ -83,12 +90,6 @@ class GreedyWordSwapWIR(SearchMethod):
                     continue
                 max_score_change = np.max(score_change)
                 delta_ps.append(max_score_change)
-
-                # Exit Loop when search_over is True - but we need to make sure delta_ps
-                # is the same size as softmax_saliency_scores
-                if search_over:
-                    delta_ps = delta_ps + [0.0] * (len_text - len(delta_ps))
-                    break
 
             index_scores = softmax_saliency_scores * np.array(delta_ps)
 

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -65,13 +65,15 @@ class GreedyWordSwapWIR(SearchMethod):
             # compute the largest change in score we can find by swapping each word
             delta_ps = []
             for idx in indices_to_order:
-                
+
                 # Exit Loop when search_over is True - but we need to make sure delta_ps
                 # is the same size as softmax_saliency_scores
                 if search_over:
-                    delta_ps = delta_ps + [0.0] * (len(softmax_saliency_scores) - len(delta_ps))
+                    delta_ps = delta_ps + [0.0] * (
+                        len(softmax_saliency_scores) - len(delta_ps)
+                    )
                     break
-                
+
                 transformed_text_candidates = self.get_transformations(
                     initial_text,
                     original_text=initial_text,


### PR DESCRIPTION
# What does this PR do?

## Summary
*There is a corner-case when `saliency_scores`  length is not equal to `len_text` , 
this happens when the query budget limits calculations of `leave_one_results`.*

## Additions

## Changes
- Moved `search_over` check to the start of the loop . 
- Changed `delta_ps` update when search_over = True. 
 
## Deletions

Fixes Issue raised by @pratyushmaini in #654

## Checklist
- [X] The title of your pull request should be a summary of its contribution.
- [X] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [X] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [X] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
