### PR TITLE
Improve exception handling for WordSwapChangeNumber

### DIFF
--- a/textattack/transformations/word_swaps/word_swap_change_number.py
+++ b/textattack/transformations/word_swaps/word_swap_change_number.py
@@ -96,7 +96,7 @@ class WordSwapChangeNumber(WordSwap):
                 num = w2n.word_to_num(word)
                 num_list = self._alter_number(num)
                 return [num2words(n) for n in num_list]
-            except ValueError:
+            except (ValueError, IndexError):
                 return []
 
     def _alter_number(self, num):


### PR DESCRIPTION
# What does this PR do?
Improve exception handling.

## Summary
- I was running `CheckList` attack on `bert-base-uncased-ag-news` and caught an exception.
```bash
dang@local:~$ textattack attack --recipe checklist --model bert-base-uncased-ag-news --num-examples 1000 --random-seed 42 --log-to-csv log.csv --disable-stdout --shuffle
[Succeeded / Failed / Skipped / Total] 10 / 431 / 20 / 461:  46%|████▌     | 461/1000 [02:57<03:27,  2.60it/s]
Traceback (most recent call last):
  File "/root/miniconda3/envs/tattack/bin/textattack", line 8, in <module>
    sys.exit(main())
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/commands/textattack_cli.py", line 50, in main
    func.run(args)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/commands/attack_command.py", line 36, in run
    attacker.attack_dataset()
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attacker.py", line 441, in attack_dataset
    self._attack()
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attacker.py", line 170, in _attack
    raise e
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attacker.py", line 168, in _attack
    result = self.attack.attack(example, ground_truth_output)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attack.py", line 423, in attack
    result = self._attack(goal_function_result)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attack.py", line 371, in _attack
    final_result = self.search_method(initial_result)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/search_methods/search_method.py", line 36, in __call__
    result = self.perform_search(initial_result)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/search_methods/beam_search.py", line 32, in perform_search
    transformations = self.get_transformations(
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attack.py", line 278, in get_transformations
    transformed_texts = self._get_transformations_uncached(
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/attack.py", line 246, in _get_transformations_uncached
    transformed_texts = self.transformation(
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/transformations/composite_transformation.py", line 39, in __call__
    new_attacked_texts.update(transformation(*args, **kwargs))
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/transformations/transformation.py", line 50, in __call__
    transformed_texts = self._get_transformations(current_text, indices_to_modify)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/transformations/word_swaps/word_swap_change_number.py", line 74, in _get_transformations
    replacement_words = self._get_new_number(word)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/textattack/transformations/word_swaps/word_swap_change_number.py", line 96, in _get_new_number
    num = w2n.word_to_num(word)
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/word2number/w2n.py", line 188, in word_to_num
    million_multiplier = number_formation(clean_numbers[0:million_index])
  File "/root/miniconda3/envs/tattack/lib/python3.8/site-packages/word2number/w2n.py", line 104, in number_formation
    return numbers[0]
IndexError: list index out of range
```

- The sample that caused the exception: 
```
Mets Introduce New Prize Pitcher Pedro (AP) AP - Pedro Martinez formalized a  #36;53 million, four-year contract with the New York Mets on Thursday and embraced the idea of helping rebuild a team that has fallen on hard times.
```

- You can quickly replicate the results by running the following script
```python
from textattack.transformations import WordSwapChangeNumber
from textattack.augmentation import Augmenter

transformation = WordSwapChangeNumber()
augmenter = Augmenter(transformation=transformation)
s = 'Mets Introduce New Prize Pitcher Pedro (AP) AP - Pedro Martinez formalized a  #36;53 million, four-year contract with the New York Mets on Thursday and embraced the idea of helping rebuild a team that has fallen on hard times.'
augmenter.augment(s)
```

- After digging further, I found that it was due to improper parsing (`... 53 million, four-year ...` got parsed to `[million, four, year]`) which led to an `IndexError` in `w2n.word_to_num()`, 

- I think a quick fix for this is to ignore the `IndexError` exception, but the best solution would be to improve the num_word parsing. 

## Changes
- Change `except ValueError` to `except (ValueError, IndexError)`

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [ ] Make sure existing tests pass.
- [ ] Add relevant tests. No quality testing = no merge.
- [x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
