### PR TITLE
Fix a issue may caused by attacked_text.py

### DIFF
--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -470,9 +470,6 @@ class AttackedText:
             perturbed_text += adv_word_seq
         perturbed_text += original_text  # Add all of the ending punctuation.
 
-        # Add pointer to self so chain of replacements can be reconstructed.
-        new_attack_attrs["prev_attacked_text"] = self
-
         # Reform perturbed_text into an OrderedDict.
         perturbed_input_texts = perturbed_text.split(AttackedText.SPLIT_TOKEN)
         perturbed_input = OrderedDict(


### PR DESCRIPTION
# Delete a repeat save parameters, it can lead to code in no response in some situation

## Summary
Lines 404 and 474 of the code store the same parameters, so delete line 474. 
If two identical parameters are saved at the same time, a long list of "prev_attacked_text" needs to be maintained internally when call `get_transformations` multiple times to generate `transformed_texts`. ` __eq__` function in `AttackedText` class is called repeatedly each time whether the `transformed_texts` exists in `constraints_cache`, and `__eq__` function compares all parameters item by item. If comparing "prev_attacked_text" with "previous_ attacked_text" will enter the linked list saved by each other, sometimes the layers are very deep, the code can get stuck for a long time comparing them, eventually the code will not continue to run normally.

## Deletions
- delete code line 474
`new_attack_attrs["prev_attacked_text"] = self`