### PR TITLE
Fixed a batch_size bug in attack_args.py

### DIFF
--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -708,6 +708,7 @@ class _CommandLineAttackArgs:
             if args.query_budget:
                 recipe.goal_function.query_budget = args.query_budget
             recipe.goal_function.model_cache_size = args.model_cache_size
+            recipe.goal_function.batch_size = args.model_batch_size
             recipe.constraint_cache_size = args.constraint_cache_size
             return recipe
         elif args.attack_from_file:


### PR DESCRIPTION
This change fixes the bug where "--model-batch-size" doesn't function when "--attack-recipe" argument is present.

# What does this PR do?
This change fixes the bug where "--model-batch-size" doesn't function when "--attack-recipe" argument is present.

## Additions
- *Example: Added a line to set `goal_function.batch_size` to `model_batch_size` argument. 

## Deletions
None. 

## Checklist
- [  ] The title of your pull request should be a summary of its contribution.
- [  ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
