### PR TITLE
fix potential bug in the filter_by_labels_ method of the Dataset class

### DIFF
--- a/textattack/datasets/dataset.py
+++ b/textattack/datasets/dataset.py
@@ -125,7 +125,7 @@ class Dataset(torch.utils.data.Dataset):
         """
         if not isinstance(labels_to_keep, set):
             labels_to_keep = set(labels_to_keep)
-        self._dataset = filter(lambda x: x[1] in labels_to_keep, self._dataset)
+        self._dataset = list(filter(lambda x: x[1] in labels_to_keep, self._dataset))
 
     def __getitem__(self, i):
         """Return i-th sample."""


### PR DESCRIPTION
# What does this PR do?

## Summary

This PR fixes Issue #745 .

## Additions

NA

## Changes

The last line of `textattack.datasets.dataset.Dataset.filter_by_labels_` changed from

```python
self._dataset = filter(lambda x: x[1] in labels_to_keep, self._dataset)
```

to

```python
self._dataset = list(filter(lambda x: x[1] in labels_to_keep, self._dataset))
```

## Deletions
NA

## Checklist
- [  ] The title of your pull request should be a summary of its contribution.
- [  ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
