### PR TITLE
Consistent word swap

### DIFF
--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -33,6 +33,36 @@ def test_word_swap_change_location():
     assert entity_original == entity_augmented
 
 
+def test_word_swap_change_location_consistent():
+    from flair.data import Sentence
+    from flair.models import SequenceTagger
+
+    from textattack.augmentation import Augmenter
+    from textattack.transformations.word_swaps import WordSwapChangeLocation
+
+    augmenter = Augmenter(transformation=WordSwapChangeLocation(consistent=True))
+    s = "I am in New York. I love living in New York."
+    s_augmented = augmenter.augment(s)
+    augmented_text = Sentence(s_augmented[0])
+    tagger = SequenceTagger.load("flair/ner-english")
+    original_text = Sentence(s)
+    tagger.predict(original_text)
+    tagger.predict(augmented_text)
+
+    entity_original = []
+    entity_augmented = []
+
+    for entity in original_text.get_spans("ner"):
+        entity_original.append(entity.tag)
+    for entity in augmented_text.get_spans("ner"):
+        entity_augmented.append(entity.tag)
+
+    print(entity_original)
+
+    assert entity_original == entity_augmented
+    assert s_augmented[0].count("New York") == 0
+
+
 def test_word_swap_change_name():
     from flair.data import Sentence
     from flair.models import SequenceTagger
@@ -57,6 +87,34 @@ def test_word_swap_change_name():
     for entity in augmented_text.get_spans("ner"):
         entity_augmented.append(entity.tag)
     assert entity_original == entity_augmented
+
+
+def test_word_swap_change_name_consistent():
+    from flair.data import Sentence
+    from flair.models import SequenceTagger
+
+    from textattack.augmentation import Augmenter
+    from textattack.transformations.word_swaps import WordSwapChangeName
+
+    augmenter = Augmenter(transformation=WordSwapChangeName(consistent=True))
+    s = "My name is Anthony Davis. Anthony Davis plays basketball."
+    s_augmented = augmenter.augment(s)
+    augmented_text = Sentence(s_augmented[0])
+    tagger = SequenceTagger.load("flair/ner-english")
+    original_text = Sentence(s)
+    tagger.predict(original_text)
+    tagger.predict(augmented_text)
+
+    entity_original = []
+    entity_augmented = []
+
+    for entity in original_text.get_spans("ner"):
+        entity_original.append(entity.tag)
+    for entity in augmented_text.get_spans("ner"):
+        entity_augmented.append(entity.tag)
+
+    assert entity_original == entity_augmented
+    assert s_augmented[0].count("Anthony") == 0 or s_augmented[0].count("Davis") == 0
 
 
 def test_chinese_morphonym_character_swap():

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -57,8 +57,6 @@ def test_word_swap_change_location_consistent():
     for entity in augmented_text.get_spans("ner"):
         entity_augmented.append(entity.tag)
 
-    print(entity_original)
-
     assert entity_original == entity_augmented
     assert s_augmented[0].count("New York") == 0
 

--- a/textattack/transformations/word_swaps/word_swap_change_location.py
+++ b/textattack/transformations/word_swaps/word_swap_change_location.py
@@ -159,7 +159,6 @@ class WordSwapChangeLocation(WordSwap):
         max_length = location_words[0][0][-1] - location_words[0][0][0] + 1
 
         for idx, location in location_words:
-
             words_in_location = idx[-1] - idx[0] + 1
             found = False
             location_start = idx[0]

--- a/textattack/transformations/word_swaps/word_swap_change_location.py
+++ b/textattack/transformations/word_swaps/word_swap_change_location.py
@@ -96,11 +96,13 @@ class WordSwapChangeLocation(WordSwap):
                             for j in range(1, len(idx)):
                                 indices_to_delete.append(i + j)
 
-                    transformed_texts.append(current_text.replace_words_at_indices(
-                        location_to_indices[word] + indices_to_delete,
-                        ([r] * len(location_to_indices[word]))
-                        + ([""] * len(indices_to_delete)),
-                    ))
+                    transformed_texts.append(
+                        current_text.replace_words_at_indices(
+                            location_to_indices[word] + indices_to_delete,
+                            ([r] * len(location_to_indices[word]))
+                            + ([""] * len(indices_to_delete)),
+                        )
+                    )
 
                     # Delete this word to mark it as replaced
                     del location_to_indices[word]
@@ -108,7 +110,12 @@ class WordSwapChangeLocation(WordSwap):
                     # If the original location is more than a single word, keep only the starting word
                     # and replace the starting word with the new word
                     indices_to_delete = idx[1:]
-                    transformed_texts.append(current_text.replace_words_at_indices([idx[0]] + indices_to_delete, [r] + [""] * len(indices_to_delete)))
+                    transformed_texts.append(
+                        current_text.replace_words_at_indices(
+                            [idx[0]] + indices_to_delete,
+                            [r] + [""] * len(indices_to_delete),
+                        )
+                    )
 
         return transformed_texts
 

--- a/textattack/transformations/word_swaps/word_swap_change_location.py
+++ b/textattack/transformations/word_swaps/word_swap_change_location.py
@@ -2,6 +2,8 @@
 Word Swap by Changing Location
 -------------------------------
 """
+from collections import defaultdict
+
 import more_itertools as mit
 import numpy as np
 
@@ -25,12 +27,15 @@ def idx_to_words(ls, words):
 
 
 class WordSwapChangeLocation(WordSwap):
-    def __init__(self, n=3, confidence_score=0.7, language="en", **kwargs):
+    def __init__(
+        self, n=3, confidence_score=0.7, language="en", consistent=False, **kwargs
+    ):
         """Transformation that changes recognized locations of a sentence to
         another location that is given in the location map.
 
         :param n: Number of new locations to generate
         :param confidence_score: Location will only be changed if it's above the confidence score
+        :param consistent:  Whether to change all instances of the same location to the same new location
 
         >>> from textattack.transformations import WordSwapChangeLocation
         >>> from textattack.augmentation import Augmenter
@@ -44,6 +49,7 @@ class WordSwapChangeLocation(WordSwap):
         self.n = n
         self.confidence_score = confidence_score
         self.language = language
+        self.consistent = consistent
 
     def _get_transformations(self, current_text, indices_to_modify):
         words = current_text.words
@@ -64,26 +70,46 @@ class WordSwapChangeLocation(WordSwap):
         location_idx = [list(group) for group in mit.consecutive_groups(location_idx)]
         location_words = idx_to_words(location_idx, words)
 
+        if self.consistent:
+            location_to_indices = defaultdict(list)
+            for idx, location in location_words:
+                location_to_indices[self._capitalize(location)].append(idx[0])
+
         transformed_texts = []
         for location in location_words:
             idx = location[0]
-            word = location[1].capitalize()
+            word = self._capitalize(location[1])
             replacement_words = self._get_new_location(word)
             for r in replacement_words:
                 if r == word:
                     continue
-                text = current_text
 
-                # if original location is more than a single word, remain only the starting word
-                if len(idx) > 1:
-                    index = idx[1]
-                    for i in idx[1:]:
-                        text = text.delete_word_at_index(index)
+                if self.consistent:
+                    # If we're doing consistent replacements, only replace the word
+                    # if it hasn't already been replaced in a previous iteration
+                    if word not in location_to_indices:
+                        continue
 
-                # replace the starting word with new location
-                text = text.replace_word_at_index(idx[0], r)
+                    indices_to_delete = []
+                    if len(idx) > 1:
+                        for i in location_to_indices[word]:
+                            for j in range(1, len(idx)):
+                                indices_to_delete.append(i + j)
 
-                transformed_texts.append(text)
+                    transformed_texts.append(current_text.replace_words_at_indices(
+                        location_to_indices[word] + indices_to_delete,
+                        ([r] * len(location_to_indices[word]))
+                        + ([""] * len(indices_to_delete)),
+                    ))
+
+                    # Delete this word to mark it as replaced
+                    del location_to_indices[word]
+                else:
+                    # If the original location is more than a single word, keep only the starting word
+                    # and replace the starting word with the new word
+                    indices_to_delete = idx[1:]
+                    transformed_texts.append(current_text.replace_words_at_indices([idx[0]] + indices_to_delete, [r] + [""] * len(indices_to_delete)))
+
         return transformed_texts
 
     def _get_new_location(self, word):
@@ -101,3 +127,7 @@ class WordSwapChangeLocation(WordSwap):
         elif word in NAMED_ENTITIES["city"]:
             return np.random.choice(NAMED_ENTITIES["city"], self.n)
         return []
+
+    def _capitalize(self, string):
+        """Capitalizes all words in the string."""
+        return " ".join(word.capitalize() for word in string.split())


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR adds a new `consistent` parameter to `WordSwapChangeLocation` and `WordSwapChangeName` so that all original instances of the same word get updated to the same new word. This allows for consistency when the semantics of the words matter. For example,  "Alice likes Bob. Alice does not like Eve." could be transformed into "Kate likes Bob. Kate does not like Eve" if `consistent = True`. Otherwise, the text could be transformed into "Alice likes Bob. Kate does not like Eve." which alters the semantics of the sentence. 

## Additions
- Added `consistent` parameter to `WordSwapChangeLocation` and `WordSwapChangeName`. 

## Changes
- `WordSwapChangeLocation` has been updated to only make one modification to the original text for marginal  performance gains. 
- `WordSwapChangeLocation` has been updated to correctly capitalize locations consisting of more than one word to match the naming convention used in `textattack/shared/data.py`. This change allows for replacement words for such multi-word locations to be found. 

## Checklist
- [ x ] The title of your pull request should be a summary of its contribution.
- [ x ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [ x ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [ x ] To indicate a work in progress please mark it as a draft on Github.
- [ x ] Make sure existing tests pass.
- [ x ] Add relevant tests. No quality testing = no merge.
- [ x ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
