### PR TITLE
Increase the swap file size of the GitHub actions runner

### DIFF
--- a/.github/workflows/run-pytest.yml
+++ b/.github/workflows/run-pytest.yml
@@ -40,6 +40,16 @@ jobs:
         sudo rm -rf /usr/local/lib/android >/dev/null 2>&1
         docker rmi $(docker image ls -aq) >/dev/null 2>&1
         df -h
+    - name: Increase swap space
+      run: |
+        swapon --show
+        export SWAP_FILE=$(swapon --show=NAME | tail -n 1)
+        sudo swapoff $SWAP_FILE
+        sudo dd if=/dev/zero of=$SWAP_FILE bs=1M count=8k oflag=append conv=notrunc # Increase by 8GB
+        sudo chmod 0600 $SWAP_FILE
+        sudo mkswap $SWAP_FILE
+        sudo swapon $SWAP_FILE
+        swapon --show
     - name: Test with pytest
       run: |
         pytest tests -v


### PR DESCRIPTION
# What does this PR do?

## Summary
The "Test with PyTest" GitHub action is failing inconsistently. On my local machine, all tests pass, but when run through [GitHub actions](https://github.com/QData/TextAttack/actions/runs/6425242361/job/17931194310), the operation fails with the below message:
```
tests/test_command_line/test_train.py::test_train_tiny 
Error: The operation was canceled.
```
When I profile this test on my local machine, it consumes over 8GB of memory, which is more than the default Ubuntu runner has. As such, I believe the test is flaky due to running out of memory. This PR addresses this by adding an additional 8GB to the swap file. 


## Additions
- Increased the swap file size for the GitHub actions runner by 8GB 

## Changes
- N/A

## Deletions
- N/A

## Checklist
- [ X  ] The title of your pull request should be a summary of its contribution.
- [ X ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [ X ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [ X ] To indicate a work in progress please mark it as a draft on Github.
- [ X ] Make sure existing tests pass.
- [ X ] Add relevant tests. No quality testing = no merge.
- [ X ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
