### PR TITLE
Word Swap Qwerty Failure Bug Fix

### DIFF
--- a/textattack/transformations/word_swaps/word_swap_qwerty.py
+++ b/textattack/transformations/word_swaps/word_swap_qwerty.py
@@ -90,10 +90,12 @@ class WordSwapQWERTY(WordSwap):
 
         if self.random_one:
             i = random.randrange(start_idx, end_idx + 1)
-            candidate_word = (
-                word[:i] + random.choice(self._get_adjacent(word[i])) + word[i + 1 :]
-            )
-            candidate_words.append(candidate_word)
+            adjacent_chars = self._get_adjacent(word[i])
+            if len(adjacent_chars) > 0:
+                candidate_word = (
+                    word[:i] + random.choice(adjacent_chars) + word[i + 1 :]
+                )
+                candidate_words.append(candidate_word)
         else:
             for i in range(start_idx, end_idx + 1):
                 for swap_key in self._get_adjacent(word[i]):


### PR DESCRIPTION
## Summary
This PR fixes an IndexError in WordSwapQWERTY when random_one is True and the word contains non-qwerty characters.

This PR is related to #717 

## Changes
- Check if the adjacent_char list is empty before calling random.choice

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [x] Make sure existing tests pass.
- [x] Add relevant tests. No quality testing = no merge.
- [x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
