### PR TITLE
Rename BERT constraint to SBERT

### DIFF
--- a/docs/apidoc/textattack.constraints.semantics.sentence_encoders.rst
+++ b/docs/apidoc/textattack.constraints.semantics.sentence_encoders.rst
@@ -11,7 +11,7 @@ textattack.constraints.semantics.sentence\_encoders package
 .. toctree::
    :maxdepth: 6
 
-   textattack.constraints.semantics.sentence_encoders.bert
+   textattack.constraints.semantics.sentence_encoders.sentence_bert
    textattack.constraints.semantics.sentence_encoders.infer_sent
    textattack.constraints.semantics.sentence_encoders.universal_sentence_encoder
 

--- a/docs/apidoc/textattack.constraints.semantics.sentence_encoders.sentence_bert.rst
+++ b/docs/apidoc/textattack.constraints.semantics.sentence_encoders.sentence_bert.rst
@@ -1,7 +1,7 @@
 textattack.constraints.semantics.sentence\_encoders.bert package
 ================================================================
 
-.. automodule:: textattack.constraints.semantics.sentence_encoders.bert
+.. automodule:: textattack.constraints.semantics.sentence_encoders.sentence_bert
    :members:
    :undoc-members:
    :show-inheritance:
@@ -9,7 +9,7 @@ textattack.constraints.semantics.sentence\_encoders.bert package
 
 
 
-.. automodule:: textattack.constraints.semantics.sentence_encoders.bert.bert
+.. automodule:: textattack.constraints.semantics.sentence_encoders.sentence_bert.sbert
    :members:
    :undoc-members:
    :show-inheritance:

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -67,7 +67,7 @@ CONSTRAINT_CLASS_NAMES = {
     # Semantics constraints
     #
     "embedding": "textattack.constraints.semantics.WordEmbeddingDistance",
-    "bert": "textattack.constraints.semantics.sentence_encoders.BERT",
+    "sbert": "textattack.constraints.semantics.sentence_encoders.SBERT",
     "infer-sent": "textattack.constraints.semantics.sentence_encoders.InferSent",
     "thought-vector": "textattack.constraints.semantics.sentence_encoders.ThoughtVector",
     "use": "textattack.constraints.semantics.sentence_encoders.UniversalSentenceEncoder",

--- a/textattack/attack_recipes/a2t_yoo_2021.py
+++ b/textattack/attack_recipes/a2t_yoo_2021.py
@@ -13,7 +13,7 @@ from textattack.constraints.pre_transformation import (
     StopwordModification,
 )
 from textattack.constraints.semantics import WordEmbeddingDistance
-from textattack.constraints.semantics.sentence_encoders import BERT
+from textattack.constraints.semantics.sentence_encoders import SBERT
 from textattack.goal_functions import UntargetedClassification
 from textattack.search_methods import GreedyWordSwapWIR
 from textattack.transformations import WordSwapEmbedding, WordSwapMaskedLM
@@ -49,7 +49,7 @@ class A2TYoo2021(AttackRecipe):
         constraints.append(input_column_modification)
         constraints.append(PartOfSpeech(allow_verb_noun_swap=False))
         constraints.append(MaxModificationRate(max_rate=0.1, min_threshold=4))
-        sent_encoder = BERT(
+        sent_encoder = SBERT(
             model_name="stsb-distilbert-base", threshold=0.9, metric="cosine"
         )
         constraints.append(sent_encoder)

--- a/textattack/constraints/semantics/sentence_encoders/__init__.py
+++ b/textattack/constraints/semantics/sentence_encoders/__init__.py
@@ -6,7 +6,7 @@ Sentence Encoder Constraint
 
 from .sentence_encoder import SentenceEncoder
 
-from .bert import BERT
+from .sentence_bert import SBERT
 from .infer_sent import InferSent
 from .thought_vector import ThoughtVector
 from .universal_sentence_encoder import (

--- a/textattack/constraints/semantics/sentence_encoders/bert/__init__.py
+++ b/textattack/constraints/semantics/sentence_encoders/bert/__init__.py
@@ -1,6 +1,0 @@
-"""
-BERT
-^^^^^^^
-"""
-
-from .bert import BERT

--- a/textattack/constraints/semantics/sentence_encoders/sentence_bert/__init__.py
+++ b/textattack/constraints/semantics/sentence_encoders/sentence_bert/__init__.py
@@ -1,0 +1,6 @@
+"""
+sBERT
+^^^^^^^
+"""
+
+from .sbert import SBERT

--- a/textattack/constraints/semantics/sentence_encoders/sentence_bert/sbert.py
+++ b/textattack/constraints/semantics/sentence_encoders/sentence_bert/sbert.py
@@ -11,7 +11,7 @@ sentence_transformers = utils.LazyLoader(
 )
 
 
-class BERT(SentenceEncoder):
+class SBERT(SentenceEncoder):
     """Constraint using similarity between sentence encodings of x and x_adv
     where the text embeddings are created using BERT, trained on NLI data, and
     fine- tuned on the STS benchmark dataset.

--- a/textattack/metrics/quality_metrics/sentence_bert.py
+++ b/textattack/metrics/quality_metrics/sentence_bert.py
@@ -7,13 +7,13 @@ Class for calculating SentenceBERT similarity on AttackResults
 """
 
 from textattack.attack_results import FailedAttackResult, SkippedAttackResult
-from textattack.constraints.semantics.sentence_encoders import BERT
+from textattack.constraints.semantics.sentence_encoders import SBERT
 from textattack.metrics import Metric
 
 
 class SBERTMetric(Metric):
     def __init__(self, **kwargs):
-        self.use_obj = BERT(model_name="all-MiniLM-L6-v2", metric="cosine")
+        self.use_obj = SBERT(model_name="all-MiniLM-L6-v2", metric="cosine")
         self.original_candidates = []
         self.successful_candidates = []
         self.all_metrics = {}


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR adds renames the BERT constraint, which is a sentence-level constraint using BERT, to SBERT to better reflect its functionality.

## Additions
- Rename `BERT` constraint to `SBERT`.

## Changes
- N/A

## Deletions
- N/A

## Checklist
- [ X ] The title of your pull request should be a summary of its contribution.
- [ X ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [ X ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [ X ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
