### PR TITLE
Fix faster-alzantot recipe references

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ To run an attack recipe: `textattack attack --recipe [recipe_name]`
 <td ><sub>Greedy replace-1 scoring and multi-transformation character-swap attack (["Black-box Generation of Adversarial Text Sequences to Evade Deep Learning Classifiers" (Gao et al., 2018)](https://arxiv.org/abs/1801.04354)</sub></td>
 </tr>
 <tr>
-<td> <code>fast-alzantot</code> <span class="citation" data-cites="Alzantot2018GeneratingNL Jia2019CertifiedRT"></span></td>
+<td> <code>faster-alzantot</code> <span class="citation" data-cites="Alzantot2018GeneratingNL Jia2019CertifiedRT"></span></td>
 <td><sub>Untargeted {Classification, Entailment}</sub></td>
 <td><sub>Percentage of words perturbed, Language Model perplexity, Word embedding distance</sub></td>
 <td><sub>Counter-fitted word embedding swap</sub></td>

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -168,7 +168,7 @@ textattack attack --model lstm-mr --num-examples 20 \
 <td ><sub>贪心搜索 replace-1 分数，多种变换的字符交换式的攻击 (["Black-box Generation of Adversarial Text Sequences to Evade Deep Learning Classifiers" (Gao et al., 2018)](https://arxiv.org/abs/1801.04354)</sub></td>
 </tr>
 <tr>
-<td> <code>fast-alzantot</code> <span class="citation" data-cites="Alzantot2018GeneratingNL Jia2019CertifiedRT"></span></td>
+<td> <code>faster-alzantot</code> <span class="citation" data-cites="Alzantot2018GeneratingNL Jia2019CertifiedRT"></span></td>
 <td><sub>无目标<br/>{分类，蕴含}</sub></td>
 <td><sub>被扰动词的比例，语言模型的困惑度，词嵌入的距离</sub></td>
 <td><sub>Counter-fitted 词嵌入替换</sub></td>

--- a/docs/1start/attacks4Components.md
+++ b/docs/1start/attacks4Components.md
@@ -123,7 +123,7 @@ A `SearchMethod` takes as input an initial `GoalFunctionResult` and returns a fi
 <td ><sub>Greedy replace-1 scoring and multi-transformation character-swap attack (["Black-box Generation of Adversarial Text Sequences to Evade Deep Learning Classifiers" (Gao et al., 2018)](https://arxiv.org/abs/1801.04354)</sub></td>
 </tr>
 <tr class="even">
-<td style="text-align: left;"> <code>fast-alzantot</code> <span class="citation" data-cites="Alzantot2018GeneratingNL Jia2019CertifiedRT"></span></td>
+<td style="text-align: left;"> <code>faster-alzantot</code> <span class="citation" data-cites="Alzantot2018GeneratingNL Jia2019CertifiedRT"></span></td>
 <td style="text-align: left;"><sub>Untargeted {Classification, Entailment}</sub></td>
 <td style="text-align: left;"><sub>Percentage of words perturbed, Language Model perplexity, Word embedding distance</sub></td>
 <td style="text-align: left;"><sub>Counter-fitted word embedding swap</sub></td>

--- a/docs/1start/what_is_an_adversarial_attack.md
+++ b/docs/1start/what_is_an_adversarial_attack.md
@@ -70,7 +70,7 @@ TextAttack attack recipes that fall under this category: deepwordbug, hotflip, p
 
 Some NLP models are trained to measure semantic similarity. Adversarial attacks based on the notion of semantic indistinguishability typically use another NLP model to enforce that perturbations are grammatically valid and semantically similar to the original input.
 
-TextAttack attack recipes that fall under this category: alzantot, bae, bert-attack, fast-alzantot, iga, kuleshov, pso, pwws, textbugger\*, textfooler
+TextAttack attack recipes that fall under this category: alzantot, bae, bert-attack, faster-alzantot, iga, kuleshov, pso, pwws, textbugger\*, textfooler
 
 \*The textbugger attack generates perturbations using both typo-like character edits and synonym substitutions. It could be considered to use both definitions of indistinguishability.
 

--- a/textattack/attack_recipes/genetic_algorithm_alzantot_2018.py
+++ b/textattack/attack_recipes/genetic_algorithm_alzantot_2018.py
@@ -5,7 +5,7 @@ Alzantot Genetic Algorithm
 (Generating Natural Language Adversarial Examples)
 
 .. warning::
-    This attack uses a very slow language model. Consider using the ``fast-alzantot``
+    This attack uses a very slow language model. Consider using the ``faster-alzantot``
     recipe instead.
 
 """


### PR DESCRIPTION
# What does this PR do?

## Summary
This fixes the typos when referring to `faster-alzantot` as `fast-alzantot` (probably some leftovers from #463 )

## Changes
- References to `faster-alzantot` in documentation, READMEs and docstrings have been fixed to refer to the correct recipe name

