### PR TITLE
fix Example_6_Chinese_Attack URL

### DIFF
--- a/docs/2notebook/Example_6_Chinese_Attack.ipynb
+++ b/docs/2notebook/Example_6_Chinese_Attack.ipynb
@@ -15,10 +15,10 @@
     "id": "6UZ0d84hEJ98"
    },
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/QData/TextAttack/blob/master/docs/2notebook/Example_6_Chinese%20Attack.ipynb)\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/QData/TextAttack/blob/master/docs/2notebook/Example_6_Chinese_Attack.ipynb)\n",
     "\n",
     "\n",
-    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/2notebook/Example_6_Chinese%20Attack.ipynb)"
+    "[![View Source on GitHub](https://img.shields.io/badge/github-view%20source-black.svg)](https://github.com/QData/TextAttack/blob/master/docs/2notebook/Example_6_Chinese_Attack.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do?

## Summary
This PR fixes the "Open in Colab" and "View source on GitHub" URLs on https://textattack.readthedocs.io/en/master/2notebook/Example_6_Chinese_Attack.html by replacing the final space with an underscore to match the correct file name.

## Changes
- Replaced the final space in the URLs with an undrscore

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [x] To indicate a work in progress please mark it as a draft on Github.
- [x] Make sure existing tests pass.
- [x] Add relevant tests. No quality testing = no merge.
- [x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
