### PR TITLE
Fix bug where EDA augmentation recipe would not accept default Augmentation arguments

### DIFF
--- a/textattack/augmentation/recipes.py
+++ b/textattack/augmentation/recipes.py
@@ -37,7 +37,7 @@ class EasyDataAugmenter(Augmenter):
     https://arxiv.org/abs/1901.11196
     """
 
-    def __init__(self, pct_words_to_swap=0.1, transformations_per_example=4):
+    def __init__(self, pct_words_to_swap=0.1, transformations_per_example=4, **kwargs):
         assert 0.0 <= pct_words_to_swap <= 1.0, "pct_words_to_swap must be in [0., 1.]"
         assert (
             transformations_per_example > 0
@@ -49,17 +49,22 @@ class EasyDataAugmenter(Augmenter):
         self.synonym_replacement = WordNetAugmenter(
             pct_words_to_swap=pct_words_to_swap,
             transformations_per_example=n_aug_each,
+            **kwargs,
         )
         self.random_deletion = DeletionAugmenter(
             pct_words_to_swap=pct_words_to_swap,
             transformations_per_example=n_aug_each,
+            **kwargs,
         )
         self.random_swap = SwapAugmenter(
             pct_words_to_swap=pct_words_to_swap,
             transformations_per_example=n_aug_each,
+            **kwargs,
         )
         self.random_insertion = SynonymInsertionAugmenter(
-            pct_words_to_swap=pct_words_to_swap, transformations_per_example=n_aug_each
+            pct_words_to_swap=pct_words_to_swap,
+            transformations_per_example=n_aug_each,
+            **kwargs,
         )
 
     def augment(self, text):


### PR DESCRIPTION
# What does this PR do?

## Summary

This PR resolves a bug where using the EDA augmentation recipe would not work with the textattack augmentation cli. This issue was because the EDA recipe did not accept the default arguments defined in the Augmentation superclass. This change resolves this issue by accepting a var-keyword parameter, which is then passed to the component Augmenter objects used by the EDA recipe.

This PR resolved the bug raised in #796, which found that running the EDA recipe from the textattack augmentation cli would raise a ``TypeError: __init__() got an unexpected keyword argument `high_yield` ``

## Changes

- Changes EDA recipe to accept a var-keyword parameter, which is passed to the component Augmenter objects
