### PR TITLE
chore: Handle empty tokenization in perplexity and allow ad-hoc Advan…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ checkpoints/
 !tests/sample_outputs/csv_attack_log.csv
 tests/test_command_line/attack_log.txt
 textattack/=22.3.0
+
+venv/

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -1,5 +1,8 @@
+import pytest
+
+
 def test_perplexity():
-    from textattack.attack_results import SuccessfulAttackResult
+    from textattack.attack_results import FailedAttackResult, SuccessfulAttackResult
     from textattack.goal_function_results.classification_goal_function_result import (
         ClassificationGoalFunctionResult,
     )
@@ -15,13 +18,87 @@ def test_perplexity():
                 AttackedText(sample_text), None, None, None, None, None, None
             ),
             ClassificationGoalFunctionResult(
-                AttackedText(sample_atck_text), None, None, None, None, None, None
+                AttackedText(
+                    sample_atck_text), None, None, None, None, None, None
             ),
         )
     ]
     ppl = Perplexity(model_name="distilbert-base-uncased").calculate(results)
 
     assert int(ppl["avg_original_perplexity"]) == int(81.95)
+
+    results = [
+        FailedAttackResult(
+            ClassificationGoalFunctionResult(
+                AttackedText(sample_text), None, None, None, None, None, None
+            ),
+        )
+    ]
+
+    Perplexity(model_name="distilbert-base-uncased").calculate(results)
+
+    ppl = Perplexity(model_name="distilbert-base-uncased")
+    texts = [sample_text]
+    ppl.ppl_tokenizer.encode(" ".join(texts), add_special_tokens=True)
+
+    encoded = ppl.ppl_tokenizer.encode(" ".join([]), add_special_tokens=True)
+    assert len(encoded) > 0
+
+
+def test_perplexity_empty_results():
+    from textattack.metrics.quality_metrics import Perplexity
+
+    ppl = Perplexity()
+    with pytest.raises(ValueError):
+        ppl.calculate([])
+
+    ppl = Perplexity("gpt2")
+    with pytest.raises(ValueError):
+        ppl.calculate([])
+
+    ppl = Perplexity(model_name="distilbert-base-uncased")
+    ppl_values = ppl.calculate([])
+
+    assert "avg_original_perplexity" in ppl_values
+    assert "avg_attack_perplexity" in ppl_values
+
+
+def test_perplexity_no_model():
+    from textattack.attack_results import FailedAttackResult, SuccessfulAttackResult
+    from textattack.goal_function_results.classification_goal_function_result import (
+        ClassificationGoalFunctionResult,
+    )
+    from textattack.metrics.quality_metrics import Perplexity
+    from textattack.shared.attacked_text import AttackedText
+
+    sample_text = "hide new secretions from the parental units "
+    sample_atck_text = "Ehide enw secretions from the parental units "
+
+    results = [
+        SuccessfulAttackResult(
+            ClassificationGoalFunctionResult(
+                AttackedText(sample_text), None, None, None, None, None, None
+            ),
+            ClassificationGoalFunctionResult(
+                AttackedText(
+                    sample_atck_text), None, None, None, None, None, None
+            ),
+        )
+    ]
+
+    ppl = Perplexity()
+    ppl_values = ppl.calculate(results)
+
+    assert "avg_original_perplexity" in ppl_values
+    assert "avg_attack_perplexity" in ppl_values
+
+
+def test_perplexity_calc_ppl():
+    from textattack.metrics.quality_metrics import Perplexity
+
+    ppl = Perplexity("gpt2")
+    with pytest.raises(ValueError):
+        ppl.calc_ppl([])
 
 
 def test_use():
@@ -85,5 +162,19 @@ def test_metric_recipe():
     attacker = Attacker(attack, dataset, attack_args)
     results = attacker.attack_dataset()
 
-    adv_score = AdvancedAttackMetric(["meteor_score", "perplexity"]).calculate(results)
+    adv_score = AdvancedAttackMetric(
+        ["meteor_score", "perplexity"]).calculate(results)
     assert adv_score["avg_attack_meteor_score"] == 0.71
+
+
+def test_metric_ad_hoc():
+    from textattack.metrics.quality_metrics import Perplexity
+    from textattack.metrics.recipe import AdvancedAttackMetric
+
+    metrics = AdvancedAttackMetric()
+    metrics.add_metric("perplexity", Perplexity(
+        model_name="distilbert-base-uncased"))
+
+    metric_results = metrics.calculate([])
+
+    assert "perplexity" in metric_results

--- a/textattack/metrics/quality_metrics/perplexity.py
+++ b/textattack/metrics/quality_metrics/perplexity.py
@@ -100,8 +100,11 @@ class Perplexity(Metric):
             input_ids = torch.tensor(
                 self.ppl_tokenizer.encode(text, add_special_tokens=True)
             ).unsqueeze(0)
+            if not (input_ids_size := input_ids.size(1)):
+                raise ValueError("No tokens recognized for input text")
+
             # Strided perplexity calculation from huggingface.co/transformers/perplexity.html
-            for i in range(0, input_ids.size(1), self.stride):
+            for i in range(0, input_ids_size, self.stride):
                 begin_loc = max(i + self.stride - self.max_length, 0)
                 end_loc = min(i + self.stride, input_ids.size(1))
                 trg_len = end_loc - i


### PR DESCRIPTION
…cedAttackMetric

# What does this PR do?
Handles empty input_ids when calculating complexity, which gave rise to RuntimeError when using "gpt2" as tokenizer.
Allows for adding metrics to AdvancedAttackMetric with configurable init params.

## Summary
This PR cleans up some confusing errors related to perplexity calculation when handling empty inputs. Instead of a RuntimeError, the perplexity calc now throws a ValueError if empty inputs are encountered. It also adds some regression
tests around this error, and makes it possible to pass a different tokenizer to the perplexity calculation in AdvancedAttackMetric.

## Additions
- Added handling of empty tokenization during Perplexity calculation.
- Added tests to test_metric_api to reproduce perplexity errors on empty inputs using "gpt2"
- Added method for appending an ad-hoc metric to AdvancedAttackMetric.

## Changes
- Perplexity with "gpt2" no longer throws torch RuntimeError on empty input_ids

## Deletions

## Checklist
- [x ] The title of your pull request should be a summary of its contribution.
- [ x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [ x] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [ x] To indicate a work in progress please mark it as a draft on Github.
- [ x] Make sure existing tests pass.
- [ x] Add relevant tests. No quality testing = no merge.
- [ x] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
