### PR TITLE
Added a remotemodelwrapper class

### DIFF
--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -34,30 +34,29 @@ class RemoteModelWrapper():
             predictions.append([result["negative"], result["positive"]])
         return torch.tensor(predictions)
 
-'''
+"""
 Example usage: 
 
-# Define the remote model API endpoint and tokenizer
-api_url = "https://x.com/predict"
+    >>> # Define the remote model API endpoint
+    >>> api_url = "https://example.com"
 
-model_wrapper = RemoteModelWrapper(api_url)
+    >>> model_wrapper = RemoteModelWrapper(api_url)
 
-# Build the attack
-attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
+    >>> # Build the attack
+    >>> attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
 
-# Define dataset and attack arguments
-dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
+    >>> # Define dataset and attack arguments
+    >>> dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
 
-attack_args = textattack.AttackArgs(
-    num_examples=100,
-    log_to_csv="/textfooler.csv",
-    checkpoint_interval=5,
-    checkpoint_dir="checkpoints", 
-    disable_stdout=True
-)
+    >>> attack_args = textattack.AttackArgs(
+    ...     num_examples=100,
+    ...     log_to_csv="/textfooler.csv",
+    ...     checkpoint_interval=5,
+    ...     checkpoint_dir="checkpoints", 
+    ...     disable_stdout=True
+    ... )
 
-# Run the attack
-attacker = textattack.Attacker(attack, dataset, attack_args)
-attacker.attack_dataset()
-
-'''
+    >>> # Run the attack
+    >>> attacker = textattack.Attacker(attack, dataset, attack_args)
+    >>> attacker.attack_dataset()
+"""

--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -10,11 +10,10 @@ import numpy as np
 import transformers
 
 class RemoteModelWrapper():
-    """This model wrapper queries a remote model with a list of text inputs. 
-    
-    It sends the input to a remote endpoint provided in api_url.
+    """This model wrapper queries a remote model with a list of text inputs.  It sends the input to a remote endpoint provided in api_url.
 
-
+    Args:
+        api_url (:obj:`<TYPE HERE>`): <DESCRIPTION HERE>
     """
     def __init__(self, api_url):
         self.api_url = api_url

--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -1,0 +1,63 @@
+"""
+RemoteModelWrapper class
+--------------------------
+
+"""
+
+import requests
+import torch
+import numpy as np
+import transformers
+
+class RemoteModelWrapper():
+    """This model wrapper queries a remote model with a list of text inputs. 
+    
+    It sends the input to a remote endpoint provided in api_url.
+
+
+    """
+    def __init__(self, api_url):
+        self.api_url = api_url
+        self.model = transformers.AutoModelForSequenceClassification.from_pretrained("textattack/bert-base-uncased-imdb")
+
+    def __call__(self, text_input_list):
+        predictions = []
+        for text in text_input_list:
+            params = dict()
+            params["text"] = text
+            response = requests.post(self.api_url, params=params, timeout=10)  # Use POST with JSON payload
+            if response.status_code != 200:
+                print(f"Response content: {response.text}")
+                raise ValueError(f"API call failed with status {response.status_code}")
+            result = response.json()
+            # Assuming the API returns probabilities for positive and negative
+            predictions.append([result["negative"], result["positive"]])
+        return torch.tensor(predictions)
+
+'''
+Example usage: 
+
+# Define the remote model API endpoint and tokenizer
+api_url = "https://x.com/predict"
+
+model_wrapper = RemoteModelWrapper(api_url)
+
+# Build the attack
+attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
+
+# Define dataset and attack arguments
+dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
+
+attack_args = textattack.AttackArgs(
+    num_examples=100,
+    log_to_csv="/textfooler.csv",
+    checkpoint_interval=5,
+    checkpoint_dir="checkpoints", 
+    disable_stdout=True
+)
+
+# Run the attack
+attacker = textattack.Attacker(attack, dataset, attack_args)
+attacker.attack_dataset()
+
+'''


### PR DESCRIPTION
# What does this PR do?
Adds a remote model wrapper class based on the TextFooler example.

## Summary
This PR adapts the Textfooler example https://textattack.readthedocs.io/en/master/_modules/textattack/attack_recipes/textfooler_jin_2019.html to instead target BERT deployed on a remote endpoint (https://x.com/predict). The remotely deployed model should bring back confidence scores in the same format as the original example (positive, negative scores).

If helpful, can share the remote model deployment files for BERT. This is part of a paper on adversarial attacks against remotely deployed models.

## Additions
- Added  textattack/models/wrappers/remote_model_wrapper.py

## Changes
- A new model wrapper class in the wrappers directory

## Deletions
None

## Checklist
- [  ] The title of your pull request should be a summary of its contribution.
- [  ] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
