### PR TITLE
Fix composite transform reproducibility

### DIFF
--- a/textattack/transformations/composite_transformation.py
+++ b/textattack/transformations/composite_transformation.py
@@ -34,10 +34,11 @@ class CompositeTransformation(Transformation):
         )
 
     def __call__(self, *args, **kwargs):
-        new_attacked_texts = set()
+        new_attacked_texts = []
         for transformation in self.transformations:
-            new_attacked_texts.update(transformation(*args, **kwargs))
-        return list(new_attacked_texts)
+            new_attacked_texts.extend(transformation(*args, **kwargs))
+        seen = set()
+        return [t for t in new_attacked_texts if not (t in seen or seen.add(t))]
 
     def __repr__(self):
         main_str = "CompositeTransformation" + "("


### PR DESCRIPTION
# What does this PR do?

## Summary
Fix unwanted non-determinism text order in `CompositeTransformation`. Not using set for text makes reproducible runs possible.

## Additions

## Changes

## Deletions

## Checklist
- [x] The title of your pull request should be a summary of its contribution.
- [x] Please write detailed description of what parts have been newly added and what parts have been modified. Please also explain why certain changes were made.
- [  ] If your pull request addresses an issue, please mention the issue number in the pull request description to make sure they are linked (and people consulting the issue know you   are working on it)
- [  ] To indicate a work in progress please mark it as a draft on Github.
- [  ] Make sure existing tests pass.
- [  ] Add relevant tests. No quality testing = no merge.
- [  ] All public methods must have informative docstrings that work nicely with sphinx. For new modules/files, please add/modify the appropriate `.rst` file in `TextAttack/docs/apidoc`.'
