### PR TITLE
fix: correct element-wise comparison in words_diff_ratio

### DIFF
--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -483,7 +483,7 @@ class AttackedText:
         Note that current text and `x` must have same number of words.
         """
         assert self.num_words == x.num_words
-        return float(np.sum(self.words != x.words)) / self.num_words
+        return float(np.sum(np.array(self.words) != np.array(x.words))) / self.num_words
 
     def align_with_model_tokens(
         self, model_wrapper: textattack.models.wrappers.ModelWrapper


### PR DESCRIPTION
## Summary

Fix `words_diff_ratio` to return correct element-wise comparison ratio instead of always returning 1/num_words.

### Problem

The method `words_diff_ratio` in `AttackedText` compares two word lists using `self.words != x.words`. Since `self.words` is a Python list, this comparison returns a single boolean value (True/False) rather than an element-wise comparison array.

```python
# Before (incorrect)
return float(np.sum(self.words != x.words)) / self.num_words
# self.words != x.words returns True (single boolean)
# np.sum(True) = 1
# Result: always 1/num_words, regardless of actual differences
```

### Fix

Convert lists to numpy arrays before comparison to enable element-wise comparison:

```python
# After (correct)
return float(np.sum(np.array(self.words) != np.array(x.words))) / self.num_words
```

### Testing

```python
from textattack.shared.attacked_text import AttackedText

text1 = AttackedText({"text": "the quick brown fox"})
text2 = AttackedText({"text": "the slow brown fox"})

# Before fix: 0.25 (1/4, incorrect)
# After fix: 0.25 (1/4, correct - only "quick" vs "slow" differs)

text3 = AttackedText({"text": "a b c d"})
text4 = AttackedText({"text": "w x y z"})

# Before fix: 0.25 (1/4, incorrect)
# After fix: 1.0 (4/4, correct - all words differ)
```

Fixes #787
