### PR TITLE
Rewrite RemoteModelWrapper to subclass ModelWrapper and generalize its API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Added
+
+- `RemoteModelWrapper` (`textattack.models.wrappers.RemoteModelWrapper`): query a model served behind a remote HTTP API instead of running it locally. Request/response handling is adaptable to different endpoint schemas via `request_fn`/`response_fn`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,5 +218,26 @@ Follow these steps to start contributing:
 
 You can run TextAttack tests with `pytest`. Just type `make test`.
 
+#### Opt-in live tests
+
+A small number of tests talk to a real, locally-running service instead of a
+mock, to sanity-check the code against an actual API rather than assumptions
+about one. These are skipped by default (and always skipped in CI) so the
+regular suite stays fast and deterministic; they only run when you set the
+env var they check for.
+
+For example, `tests/test_remote_model_wrapper.py::test_call_against_real_user_provided_url`
+exercises `RemoteModelWrapper` against a real HTTP endpoint, such as a local
+[Ollama](https://ollama.com) server:
+
+```bash
+REMOTE_MODEL_WRAPPER_TEST_URL=http://localhost:11434/api/generate \
+REMOTE_MODEL_WRAPPER_TEST_MODEL=qwen2.5:7b-instruct \
+    pytest tests/test_remote_model_wrapper.py -v
+```
+
+Leave `REMOTE_MODEL_WRAPPER_TEST_URL` unset to skip it and run only the
+mocked cases, which is what `make test`/CI do.
+
 
 #### This guide was heavily inspired by the awesome [transformers guide to contributing](https://github.com/huggingface/transformers/blob/master/CONTRIBUTING.md)

--- a/docs/1start/api-design-tips.md
+++ b/docs/1start/api-design-tips.md
@@ -34,7 +34,7 @@ One of the challenges for building such tools is that the tool should be flexibl
 ## Our design tips 
 
 We provide the following broad advice to help other future developers create user-friendly NLP libraries in Python:
-- To become model-agnostic, implement a model wrapper class: a model is anything that takes string input(s) and returns a prediction.
+- To become model-agnostic, implement a model wrapper class: a model is anything that takes string input(s) and returns a prediction. This includes models served behind a remote HTTP API, not just models loaded locally (see `textattack.models.wrappers.RemoteModelWrapper`).
 - To become data-agnostic, take dataset inputs as (input, output) pairs, where each model input is represented as an OrderedDict.
 - Do not plan for inputs (tensors, lists, etc.) to be a certain size or shape unless explicitly necessary.
 - Centralize common text operations, like parsing and string-level operations, in one class.

--- a/docs/apidoc/textattack.models.wrappers.rst
+++ b/docs/apidoc/textattack.models.wrappers.rst
@@ -27,6 +27,12 @@ textattack.models.wrappers package
    :show-inheritance:
 
 
+.. automodule:: textattack.models.wrappers.remote_model_wrapper
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
 .. automodule:: textattack.models.wrappers.sklearn_model_wrapper
    :members:
    :undoc-members:

--- a/tests/test_remote_model_wrapper.py
+++ b/tests/test_remote_model_wrapper.py
@@ -1,0 +1,159 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from textattack.models.wrappers import ModelWrapper, RemoteModelWrapper
+
+# Set this to a live endpoint to also exercise RemoteModelWrapper against a
+# real API (e.g. a local Ollama server's http://localhost:11434/api/generate).
+# Left unset, the live test below is skipped and only the mocked
+# https://example.com/predict cases run -- which is what CI does.
+#
+# To run the live test too:
+#   REMOTE_MODEL_WRAPPER_TEST_URL=http://localhost:11434/api/generate \
+#   REMOTE_MODEL_WRAPPER_TEST_MODEL=qwen2.5:7b-instruct \
+#       pytest tests/test_remote_model_wrapper.py -v
+#
+# See CONTRIBUTING.md#tests for more on when/why this test is opt-in.
+LIVE_API_URL_ENV_VAR = "REMOTE_MODEL_WRAPPER_TEST_URL"
+LIVE_API_MODEL_ENV_VAR = "REMOTE_MODEL_WRAPPER_TEST_MODEL"
+
+
+def _mock_response(status_code=200, json_body=None):
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_body or {}
+    response.text = "error body"
+    return response
+
+
+def test_is_model_wrapper_subclass_with_no_local_model():
+    wrapper = RemoteModelWrapper("https://example.com/predict")
+    assert isinstance(wrapper, ModelWrapper)
+    assert wrapper.model is None
+
+
+def test_call_posts_json_body_and_parses_default_schema():
+    wrapper = RemoteModelWrapper("https://example.com/predict")
+    mock_post = MagicMock(
+        return_value=_mock_response(json_body={"negative": 0.1, "positive": 0.9})
+    )
+    with patch(
+        "textattack.models.wrappers.remote_model_wrapper.requests.post", mock_post
+    ):
+        result = wrapper(["great movie"])
+
+    assert torch.allclose(result, torch.tensor([[0.1, 0.9]]))
+    _, call_kwargs = mock_post.call_args
+    assert call_kwargs["json"] == {"text": "great movie"}
+
+
+def test_call_raises_on_non_200_status():
+    wrapper = RemoteModelWrapper("https://example.com/predict")
+    mock_post = MagicMock(return_value=_mock_response(status_code=500))
+    with patch(
+        "textattack.models.wrappers.remote_model_wrapper.requests.post", mock_post
+    ):
+        with pytest.raises(ValueError):
+            wrapper(["great movie"])
+
+
+def test_call_supports_custom_request_and_response_fn():
+    wrapper = RemoteModelWrapper(
+        "https://example.com/predict",
+        request_fn=lambda text: {"inputs": text},
+        response_fn=lambda body: body["scores"],
+    )
+    mock_post = MagicMock(
+        return_value=_mock_response(json_body={"scores": [0.2, 0.3, 0.5]})
+    )
+    with patch(
+        "textattack.models.wrappers.remote_model_wrapper.requests.post", mock_post
+    ):
+        result = wrapper(["some text"])
+
+    assert torch.allclose(result, torch.tensor([[0.2, 0.3, 0.5]]))
+    _, call_kwargs = mock_post.call_args
+    assert call_kwargs["json"] == {"inputs": "some text"}
+
+
+def test_call_sends_one_request_per_input_in_order():
+    wrapper = RemoteModelWrapper("https://example.com/predict")
+    responses = [
+        _mock_response(json_body={"negative": 0.1, "positive": 0.9}),
+        _mock_response(json_body={"negative": 0.8, "positive": 0.2}),
+    ]
+    mock_post = MagicMock(side_effect=responses)
+    with patch(
+        "textattack.models.wrappers.remote_model_wrapper.requests.post", mock_post
+    ):
+        result = wrapper(["great movie", "terrible movie"])
+
+    assert torch.allclose(result, torch.tensor([[0.1, 0.9], [0.8, 0.2]]))
+    sent_texts = [call.kwargs["json"]["text"] for call in mock_post.call_args_list]
+    assert sent_texts == ["great movie", "terrible movie"]
+
+
+def test_call_passes_custom_timeout_to_requests():
+    wrapper = RemoteModelWrapper("https://example.com/predict", timeout=3)
+    mock_post = MagicMock(
+        return_value=_mock_response(json_body={"negative": 0.1, "positive": 0.9})
+    )
+    with patch(
+        "textattack.models.wrappers.remote_model_wrapper.requests.post", mock_post
+    ):
+        wrapper(["great movie"])
+
+    _, call_kwargs = mock_post.call_args
+    assert call_kwargs["timeout"] == 3
+
+
+@pytest.mark.skipif(
+    not os.environ.get(LIVE_API_URL_ENV_VAR),
+    reason=(
+        f"Set {LIVE_API_URL_ENV_VAR} to a live endpoint to run "
+        "RemoteModelWrapper against a real API (not run in CI)."
+    ),
+)
+def test_call_against_real_user_provided_url():
+    """Live sanity check: hits an actual HTTP endpoint, no mocking.
+
+    Example (a local Ollama server)::
+
+        REMOTE_MODEL_WRAPPER_TEST_URL=http://localhost:11434/api/generate \\
+        REMOTE_MODEL_WRAPPER_TEST_MODEL=qwen2.5:7b-instruct \\
+            pytest tests/test_remote_model_wrapper.py -k real_user_provided_url -v
+    """
+    api_url = os.environ[LIVE_API_URL_ENV_VAR]
+
+    if "/api/generate" in api_url:
+        # Ollama's generate endpoint: prompt in, generated text out. Adapt it
+        # to a sentiment classifier via prompting, same as the demo script.
+        model_name = os.environ.get(LIVE_API_MODEL_ENV_VAR, "qwen2.5:7b-instruct")
+
+        def request_fn(text):
+            prompt = (
+                "Classify the sentiment of this movie review as exactly one "
+                f'word, "positive" or "negative".\n\nReview: {text}\nSentiment:'
+            )
+            return {"model": model_name, "prompt": prompt, "stream": False}
+
+        def response_fn(body):
+            label = body["response"].strip().lower()
+            return [0.0, 1.0] if "positive" in label else [1.0, 0.0]
+
+        wrapper = RemoteModelWrapper(
+            api_url, request_fn=request_fn, response_fn=response_fn, timeout=60
+        )
+    else:
+        # Assume the endpoint implements the wrapper's default schema:
+        # {"text": ...} in, {"negative": ..., "positive": ...} out.
+        wrapper = RemoteModelWrapper(api_url, timeout=60)
+
+    result = wrapper(
+        ["This movie was an absolute masterpiece, I loved every minute of it."]
+    )
+    assert result.shape == (1, 2)
+    assert torch.argmax(result[0]).item() == 1  # positive

--- a/textattack/models/wrappers/__init__.py
+++ b/textattack/models/wrappers/__init__.py
@@ -12,5 +12,6 @@ from .model_wrapper import ModelWrapper
 
 from .huggingface_model_wrapper import HuggingFaceModelWrapper
 from .pytorch_model_wrapper import PyTorchModelWrapper
+from .remote_model_wrapper import RemoteModelWrapper
 from .sklearn_model_wrapper import SklearnModelWrapper
 from .tensorflow_model_wrapper import TensorFlowModelWrapper

--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -34,30 +34,29 @@ class RemoteModelWrapper():
             predictions.append([result["negative"], result["positive"]])
         return torch.tensor(predictions)
 
-'''
+"""
 Example usage: 
 
-# Define the remote model API endpoint and tokenizer
-api_url = "https://x.com/predict"
+    >>> # Define the remote model API endpoint
+    >>> api_url = "https://example.com"
 
-model_wrapper = RemoteModelWrapper(api_url)
+    >>> model_wrapper = RemoteModelWrapper(api_url)
 
-# Build the attack
-attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
+    >>> # Build the attack
+    >>> attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
 
-# Define dataset and attack arguments
-dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
+    >>> # Define dataset and attack arguments
+    >>> dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
 
-attack_args = textattack.AttackArgs(
-    num_examples=100,
-    log_to_csv="/textfooler.csv",
-    checkpoint_interval=5,
-    checkpoint_dir="checkpoints", 
-    disable_stdout=True
-)
+    >>> attack_args = textattack.AttackArgs(
+    ...     num_examples=100,
+    ...     log_to_csv="/textfooler.csv",
+    ...     checkpoint_interval=5,
+    ...     checkpoint_dir="checkpoints", 
+    ...     disable_stdout=True
+    ... )
 
-# Run the attack
-attacker = textattack.Attacker(attack, dataset, attack_args)
-attacker.attack_dataset()
-
-'''
+    >>> # Run the attack
+    >>> attacker = textattack.Attacker(attack, dataset, attack_args)
+    >>> attacker.attack_dataset()
+"""

--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -10,11 +10,10 @@ import numpy as np
 import transformers
 
 class RemoteModelWrapper():
-    """This model wrapper queries a remote model with a list of text inputs. 
-    
-    It sends the input to a remote endpoint provided in api_url.
+    """This model wrapper queries a remote model with a list of text inputs.  It sends the input to a remote endpoint provided in api_url.
 
-
+    Args:
+        api_url (:obj:`<TYPE HERE>`): <DESCRIPTION HERE>
     """
     def __init__(self, api_url):
         self.api_url = api_url

--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -1,0 +1,63 @@
+"""
+RemoteModelWrapper class
+--------------------------
+
+"""
+
+import requests
+import torch
+import numpy as np
+import transformers
+
+class RemoteModelWrapper():
+    """This model wrapper queries a remote model with a list of text inputs. 
+    
+    It sends the input to a remote endpoint provided in api_url.
+
+
+    """
+    def __init__(self, api_url):
+        self.api_url = api_url
+        self.model = transformers.AutoModelForSequenceClassification.from_pretrained("textattack/bert-base-uncased-imdb")
+
+    def __call__(self, text_input_list):
+        predictions = []
+        for text in text_input_list:
+            params = dict()
+            params["text"] = text
+            response = requests.post(self.api_url, params=params, timeout=10)  # Use POST with JSON payload
+            if response.status_code != 200:
+                print(f"Response content: {response.text}")
+                raise ValueError(f"API call failed with status {response.status_code}")
+            result = response.json()
+            # Assuming the API returns probabilities for positive and negative
+            predictions.append([result["negative"], result["positive"]])
+        return torch.tensor(predictions)
+
+'''
+Example usage: 
+
+# Define the remote model API endpoint and tokenizer
+api_url = "https://x.com/predict"
+
+model_wrapper = RemoteModelWrapper(api_url)
+
+# Build the attack
+attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
+
+# Define dataset and attack arguments
+dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
+
+attack_args = textattack.AttackArgs(
+    num_examples=100,
+    log_to_csv="/textfooler.csv",
+    checkpoint_interval=5,
+    checkpoint_dir="checkpoints", 
+    disable_stdout=True
+)
+
+# Run the attack
+attacker = textattack.Attacker(attack, dataset, attack_args)
+attacker.attack_dataset()
+
+'''

--- a/textattack/models/wrappers/remote_model_wrapper.py
+++ b/textattack/models/wrappers/remote_model_wrapper.py
@@ -6,56 +6,67 @@ RemoteModelWrapper class
 
 import requests
 import torch
-import numpy as np
-import transformers
 
-class RemoteModelWrapper():
-    """This model wrapper queries a remote model with a list of text inputs.  It sends the input to a remote endpoint provided in api_url.
+from .model_wrapper import ModelWrapper
+
+
+class RemoteModelWrapper(ModelWrapper):
+    """This model wrapper queries a remote model with a list of text inputs.
+    It sends each input to a remote HTTP endpoint provided in ``api_url``
+    and parses the JSON response into class scores.
+
+    Since the request and response format of a remote model is
+    API-specific, ``request_fn`` and ``response_fn`` can be provided to
+    adapt this wrapper to any endpoint. By default, the wrapper POSTs
+    ``{"text": <input>}`` as a JSON body and expects a JSON response of
+    the form ``{"negative": <score>, "positive": <score>}``.
 
     Args:
-        api_url (:obj:`<TYPE HERE>`): <DESCRIPTION HERE>
+        api_url (:obj:`str`): The URL of the remote model's inference endpoint.
+        request_fn (:obj:`Callable[[str], dict]`, `optional`): Builds the
+            JSON request payload for a single piece of text. Defaults to
+            ``lambda text: {"text": text}``.
+        response_fn (:obj:`Callable[[dict], list]`, `optional`): Extracts a
+            list of class scores from the parsed JSON response for a single
+            input. Defaults to ``lambda result: [result["negative"], result["positive"]]``.
+        timeout (:obj:`int`, `optional`, defaults to :obj:`10`): Per-request
+            timeout, in seconds.
+
+    Example::
+
+        >>> import textattack
+
+        >>> api_url = "https://example.com/predict"
+        >>> model_wrapper = textattack.models.wrappers.RemoteModelWrapper(api_url)
+
+        >>> attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
+        >>> dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
+        >>> attack_args = textattack.AttackArgs(num_examples=100)
+        >>> attacker = textattack.Attacker(attack, dataset, attack_args)
+        >>> attacker.attack_dataset()
     """
-    def __init__(self, api_url):
+
+    def __init__(self, api_url, request_fn=None, response_fn=None, timeout=10):
         self.api_url = api_url
-        self.model = transformers.AutoModelForSequenceClassification.from_pretrained("textattack/bert-base-uncased-imdb")
+        self.timeout = timeout
+        self.request_fn = request_fn or (lambda text: {"text": text})
+        self.response_fn = response_fn or (
+            lambda result: [result["negative"], result["positive"]]
+        )
+        # `RemoteModelWrapper` has no local model: the remote endpoint is the
+        # model. `GoalFunction` only uses this to check task compatibility,
+        # and gracefully warns (rather than erroring) when it's unrecognized.
+        self.model = None
 
     def __call__(self, text_input_list):
         predictions = []
         for text in text_input_list:
-            params = dict()
-            params["text"] = text
-            response = requests.post(self.api_url, params=params, timeout=10)  # Use POST with JSON payload
+            response = requests.post(
+                self.api_url, json=self.request_fn(text), timeout=self.timeout
+            )
             if response.status_code != 200:
-                print(f"Response content: {response.text}")
-                raise ValueError(f"API call failed with status {response.status_code}")
-            result = response.json()
-            # Assuming the API returns probabilities for positive and negative
-            predictions.append([result["negative"], result["positive"]])
+                raise ValueError(
+                    f"API call failed with status {response.status_code}: {response.text}"
+                )
+            predictions.append(self.response_fn(response.json()))
         return torch.tensor(predictions)
-
-"""
-Example usage: 
-
-    >>> # Define the remote model API endpoint
-    >>> api_url = "https://example.com"
-
-    >>> model_wrapper = RemoteModelWrapper(api_url)
-
-    >>> # Build the attack
-    >>> attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
-
-    >>> # Define dataset and attack arguments
-    >>> dataset = textattack.datasets.HuggingFaceDataset("imdb", split="test")
-
-    >>> attack_args = textattack.AttackArgs(
-    ...     num_examples=100,
-    ...     log_to_csv="/textfooler.csv",
-    ...     checkpoint_interval=5,
-    ...     checkpoint_dir="checkpoints", 
-    ...     disable_stdout=True
-    ... )
-
-    >>> # Run the attack
-    >>> attacker = textattack.Attacker(attack, dataset, attack_args)
-    >>> attacker.attack_dataset()
-"""


### PR DESCRIPTION
## Summary

Supersedes #809. Reworks the original `RemoteModelWrapper` (added there) to address reviewer feedback from `bterrific2008` and `yanjunqiAz`:

- Subclasses `ModelWrapper` (required for compatibility checks elsewhere in the framework, e.g. `WordSwapGradientBased`'s `isinstance` check).
- Drops the unused local HF model load in `__init__` that defeated the purpose of a "remote" wrapper.
- Sends a real JSON body (`json=`) instead of query params, fixing a comment/code mismatch.
- Generalizes request/response handling via configurable `request_fn`/`response_fn` callables instead of hardcoding one API's `{"negative", "positive"}` schema.
- Exports the class from `textattack.models.wrappers` and documents it in the Sphinx API docs.
- Fills in the previously-placeholder docstring.

## Test plan

- [x] `tests/test_remote_model_wrapper.py` (new): 6 mocked unit tests covering `ModelWrapper` subclassing, JSON-body + default schema parsing, non-200 error handling, custom `request_fn`/`response_fn`, multi-input ordering, and timeout propagation.
- [x] Opt-in live test (`test_call_against_real_user_provided_url`, skipped by default/in CI) verified manually against a real local Ollama server.
- [x] Full test suite collection (79 tests) succeeds with no errors.
- [x] `black --check` clean.

Closes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)