### PR TITLE
fix: address review findings on AdvancedAttackMetric quality metrics (PR #802 follow-up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ checkpoints/
 !tests/sample_outputs/csv_attack_log.csv
 tests/test_command_line/attack_log.txt
 textattack/=22.3.0
+
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,3 @@ checkpoints/
 !tests/sample_outputs/csv_attack_log.csv
 tests/test_command_line/attack_log.txt
 textattack/=22.3.0
-
-venv/

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -1,5 +1,8 @@
+import pytest
+
+
 def test_perplexity():
-    from textattack.attack_results import SuccessfulAttackResult
+    from textattack.attack_results import FailedAttackResult, SuccessfulAttackResult
     from textattack.goal_function_results.classification_goal_function_result import (
         ClassificationGoalFunctionResult,
     )
@@ -15,13 +18,87 @@ def test_perplexity():
                 AttackedText(sample_text), None, None, None, None, None, None
             ),
             ClassificationGoalFunctionResult(
-                AttackedText(sample_atck_text), None, None, None, None, None, None
+                AttackedText(
+                    sample_atck_text), None, None, None, None, None, None
             ),
         )
     ]
     ppl = Perplexity(model_name="distilbert-base-uncased").calculate(results)
 
     assert int(ppl["avg_original_perplexity"]) == int(81.95)
+
+    results = [
+        FailedAttackResult(
+            ClassificationGoalFunctionResult(
+                AttackedText(sample_text), None, None, None, None, None, None
+            ),
+        )
+    ]
+
+    Perplexity(model_name="distilbert-base-uncased").calculate(results)
+
+    ppl = Perplexity(model_name="distilbert-base-uncased")
+    texts = [sample_text]
+    ppl.ppl_tokenizer.encode(" ".join(texts), add_special_tokens=True)
+
+    encoded = ppl.ppl_tokenizer.encode(" ".join([]), add_special_tokens=True)
+    assert len(encoded) > 0
+
+
+def test_perplexity_empty_results():
+    from textattack.metrics.quality_metrics import Perplexity
+
+    ppl = Perplexity()
+    with pytest.raises(ValueError):
+        ppl.calculate([])
+
+    ppl = Perplexity("gpt2")
+    with pytest.raises(ValueError):
+        ppl.calculate([])
+
+    ppl = Perplexity(model_name="distilbert-base-uncased")
+    ppl_values = ppl.calculate([])
+
+    assert "avg_original_perplexity" in ppl_values
+    assert "avg_attack_perplexity" in ppl_values
+
+
+def test_perplexity_no_model():
+    from textattack.attack_results import FailedAttackResult, SuccessfulAttackResult
+    from textattack.goal_function_results.classification_goal_function_result import (
+        ClassificationGoalFunctionResult,
+    )
+    from textattack.metrics.quality_metrics import Perplexity
+    from textattack.shared.attacked_text import AttackedText
+
+    sample_text = "hide new secretions from the parental units "
+    sample_atck_text = "Ehide enw secretions from the parental units "
+
+    results = [
+        SuccessfulAttackResult(
+            ClassificationGoalFunctionResult(
+                AttackedText(sample_text), None, None, None, None, None, None
+            ),
+            ClassificationGoalFunctionResult(
+                AttackedText(
+                    sample_atck_text), None, None, None, None, None, None
+            ),
+        )
+    ]
+
+    ppl = Perplexity()
+    ppl_values = ppl.calculate(results)
+
+    assert "avg_original_perplexity" in ppl_values
+    assert "avg_attack_perplexity" in ppl_values
+
+
+def test_perplexity_calc_ppl():
+    from textattack.metrics.quality_metrics import Perplexity
+
+    ppl = Perplexity("gpt2")
+    with pytest.raises(ValueError):
+        ppl.calc_ppl([])
 
 
 def test_use():
@@ -85,5 +162,19 @@ def test_metric_recipe():
     attacker = Attacker(attack, dataset, attack_args)
     results = attacker.attack_dataset()
 
-    adv_score = AdvancedAttackMetric(["meteor_score", "perplexity"]).calculate(results)
+    adv_score = AdvancedAttackMetric(
+        ["meteor_score", "perplexity"]).calculate(results)
     assert adv_score["avg_attack_meteor_score"] == 0.71
+
+
+def test_metric_ad_hoc():
+    from textattack.metrics.quality_metrics import Perplexity
+    from textattack.metrics.recipe import AdvancedAttackMetric
+
+    metrics = AdvancedAttackMetric()
+    metrics.add_metric("perplexity", Perplexity(
+        model_name="distilbert-base-uncased"))
+
+    metric_results = metrics.calculate([])
+
+    assert "perplexity" in metric_results

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -63,7 +63,7 @@ def test_perplexity_empty_results():
 
 
 def test_perplexity_no_model():
-    from textattack.attack_results import FailedAttackResult, SuccessfulAttackResult
+    from textattack.attack_results import SuccessfulAttackResult
     from textattack.goal_function_results.classification_goal_function_result import (
         ClassificationGoalFunctionResult,
     )

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -171,10 +171,11 @@ def test_metric_ad_hoc():
     from textattack.metrics.quality_metrics import Perplexity
     from textattack.metrics.recipe import AdvancedAttackMetric
 
-    metrics = AdvancedAttackMetric()
+    metrics = AdvancedAttackMetric(choices=[])
     metrics.add_metric("perplexity", Perplexity(
         model_name="distilbert-base-uncased"))
 
     metric_results = metrics.calculate([])
 
-    assert "perplexity" in metric_results
+    assert "avg_original_perplexity" in metric_results
+    assert "avg_attack_perplexity" in metric_results

--- a/tests/test_metric_api.py
+++ b/tests/test_metric_api.py
@@ -18,8 +18,7 @@ def test_perplexity():
                 AttackedText(sample_text), None, None, None, None, None, None
             ),
             ClassificationGoalFunctionResult(
-                AttackedText(
-                    sample_atck_text), None, None, None, None, None, None
+                AttackedText(sample_atck_text), None, None, None, None, None, None
             ),
         )
     ]
@@ -80,8 +79,7 @@ def test_perplexity_no_model():
                 AttackedText(sample_text), None, None, None, None, None, None
             ),
             ClassificationGoalFunctionResult(
-                AttackedText(
-                    sample_atck_text), None, None, None, None, None, None
+                AttackedText(sample_atck_text), None, None, None, None, None, None
             ),
         )
     ]
@@ -162,8 +160,7 @@ def test_metric_recipe():
     attacker = Attacker(attack, dataset, attack_args)
     results = attacker.attack_dataset()
 
-    adv_score = AdvancedAttackMetric(
-        ["meteor_score", "perplexity"]).calculate(results)
+    adv_score = AdvancedAttackMetric(["meteor_score", "perplexity"]).calculate(results)
     assert adv_score["avg_attack_meteor_score"] == 0.71
 
 
@@ -172,8 +169,7 @@ def test_metric_ad_hoc():
     from textattack.metrics.recipe import AdvancedAttackMetric
 
     metrics = AdvancedAttackMetric(choices=[])
-    metrics.add_metric("perplexity", Perplexity(
-        model_name="distilbert-base-uncased"))
+    metrics.add_metric("perplexity", Perplexity(model_name="distilbert-base-uncased"))
 
     metric_results = metrics.calculate([])
 

--- a/textattack/metrics/quality_metrics/bert_score.py
+++ b/textattack/metrics/quality_metrics/bert_score.py
@@ -50,6 +50,8 @@ class BERTScoreMetric(Metric):
         """
 
         self.results = results
+        self.original_candidates = []
+        self.successful_candidates = []
 
         for i, result in enumerate(self.results):
             if isinstance(result, FailedAttackResult):
@@ -59,6 +61,9 @@ class BERTScoreMetric(Metric):
             else:
                 self.original_candidates.append(result.original_result.attacked_text)
                 self.successful_candidates.append(result.perturbed_result.attacked_text)
+
+        if not self.original_candidates:
+            raise ValueError("No successful attack results to calculate BERTScore")
 
         sbert_scores = []
         for c in range(len(self.original_candidates)):

--- a/textattack/metrics/quality_metrics/meteor_score.py
+++ b/textattack/metrics/quality_metrics/meteor_score.py
@@ -48,6 +48,8 @@ class MeteorMetric(Metric):
         """
 
         self.results = results
+        self.original_candidates = []
+        self.successful_candidates = []
 
         for i, result in enumerate(self.results):
             if isinstance(result, FailedAttackResult):
@@ -61,6 +63,9 @@ class MeteorMetric(Metric):
                 self.successful_candidates.append(
                     result.perturbed_result.attacked_text.text
                 )
+
+        if not self.original_candidates:
+            raise ValueError("No successful attack results to calculate METEOR score")
 
         meteor_scores = []
         for c in range(len(self.original_candidates)):

--- a/textattack/metrics/quality_metrics/perplexity.py
+++ b/textattack/metrics/quality_metrics/perplexity.py
@@ -100,8 +100,11 @@ class Perplexity(Metric):
             input_ids = torch.tensor(
                 self.ppl_tokenizer.encode(text, add_special_tokens=True)
             ).unsqueeze(0)
+            if not (input_ids_size := input_ids.size(1)):
+                raise ValueError("No tokens recognized for input text")
+
             # Strided perplexity calculation from huggingface.co/transformers/perplexity.html
-            for i in range(0, input_ids.size(1), self.stride):
+            for i in range(0, input_ids_size, self.stride):
                 begin_loc = max(i + self.stride - self.max_length, 0)
                 end_loc = min(i + self.stride, input_ids.size(1))
                 trg_len = end_loc - i

--- a/textattack/metrics/quality_metrics/perplexity.py
+++ b/textattack/metrics/quality_metrics/perplexity.py
@@ -68,8 +68,8 @@ class Perplexity(Metric):
             >> ppl = textattack.metrics.quality_metrics.Perplexity().calculate(results)
         """
         self.results = results
-        self.original_candidates_ppl = []
-        self.successful_candidates_ppl = []
+        self.original_candidates = []
+        self.successful_candidates = []
 
         for i, result in enumerate(self.results):
             if isinstance(result, FailedAttackResult):

--- a/textattack/metrics/quality_metrics/sentence_bert.py
+++ b/textattack/metrics/quality_metrics/sentence_bert.py
@@ -49,6 +49,8 @@ class SBERTMetric(Metric):
         """
 
         self.results = results
+        self.original_candidates = []
+        self.successful_candidates = []
 
         for i, result in enumerate(self.results):
             if isinstance(result, FailedAttackResult):
@@ -58,6 +60,11 @@ class SBERTMetric(Metric):
             else:
                 self.original_candidates.append(result.original_result.attacked_text)
                 self.successful_candidates.append(result.perturbed_result.attacked_text)
+
+        if not self.original_candidates:
+            raise ValueError(
+                "No successful attack results to calculate Sentence BERT similarity"
+            )
 
         sbert_scores = []
         for c in range(len(self.original_candidates)):

--- a/textattack/metrics/quality_metrics/use.py
+++ b/textattack/metrics/quality_metrics/use.py
@@ -49,6 +49,8 @@ class USEMetric(Metric):
         """
 
         self.results = results
+        self.original_candidates = []
+        self.successful_candidates = []
 
         for i, result in enumerate(self.results):
             if isinstance(result, FailedAttackResult):
@@ -58,6 +60,9 @@ class USEMetric(Metric):
             else:
                 self.original_candidates.append(result.original_result.attacked_text)
                 self.successful_candidates.append(result.perturbed_result.attacked_text)
+
+        if not self.original_candidates:
+            raise ValueError("No successful attack results to calculate USE score")
 
         use_scores = []
         for c in range(len(self.original_candidates)):

--- a/textattack/metrics/recipe.py
+++ b/textattack/metrics/recipe.py
@@ -4,6 +4,8 @@ Attack Metric Quality Recipes:
 
 """
 
+from __future__ import annotations
+
 from textattack.metrics.quality_metrics.bert_score import BERTScoreMetric
 from textattack.metrics.quality_metrics.meteor_score import MeteorMetric
 from textattack.metrics.quality_metrics.perplexity import Perplexity
@@ -17,30 +19,38 @@ class AdvancedAttackMetric(Metric):
     """Calculate a suite of advanced metrics to evaluate attackResults'
     quality."""
 
+    _AVAILABLE_METRICS = {
+        "use": USEMetric,
+        "perplexity": Perplexity,
+        "bert_score": BERTScoreMetric,
+        "meteor_score": MeteorMetric,
+        "sbert_score": SBERTMetric,
+    }
+
     def __init__(self, choices: list[str] = ["use"]):
-        self.achoices = choices
-        available_metrics = {
-            "use": USEMetric,
-            "perplexity": Perplexity,
-            "bert_score": BERTScoreMetric,
-            "meteor_score": MeteorMetric,
-            "sbert_score": SBERTMetric,
-        }
         self.selected_metrics = {}
-        for choice in self.achoices:
-            if choice not in available_metrics:
-                raise KeyError(f"'{choice}' is not a valid metric name")
-            metric = available_metrics[choice]()
-            self.selected_metrics.update({choice: metric})
+        for choice in choices:
+            if choice not in self._AVAILABLE_METRICS:
+                raise ValueError(f"'{choice}' is not a valid metric name")
+            # Construction (and any pretrained model loading) is deferred
+            # until `calculate()` actually needs the metric.
+            self.selected_metrics[choice] = self._AVAILABLE_METRICS[choice]
+
+    @property
+    def achoices(self):
+        return list(self.selected_metrics.keys())
 
     def add_metric(self, name: str, metric: Metric):
         if not isinstance(metric, Metric):
             raise ValueError(f"Object {metric} must be a subtype of Metric")
-        self.selected_metrics.update({name: metric})
+        self.selected_metrics[name] = metric
 
     def calculate(self, results) -> dict[str, float]:
         advanced_metrics = {}
         # TODO: Would like to guarantee unique keys from calls to calculate()
-        for metric in self.selected_metrics.values():
+        for name, metric in self.selected_metrics.items():
+            if isinstance(metric, type):
+                metric = metric()
+                self.selected_metrics[name] = metric
             advanced_metrics.update(metric.calculate(results))
         return advanced_metrics


### PR DESCRIPTION
## Summary
Builds on #802 (`chore: Handle empty tokenization in perplexity and allow ad-hoc AdvancedAttackMetric`) and addresses review findings from that PR:

- Add `from __future__ import annotations` so the PEP 585 generics (`list[str]`, `dict[str, float]`) in `recipe.py` don't break Python 3.8 CI.
- Reset `original_candidates`/`successful_candidates` at the start of every `calculate()` call across all quality metrics, so metric instances cached/reused via `AdvancedAttackMetric` no longer silently accumulate results across calls.
- Add the empty-candidates guard already present in `Perplexity` to `USEMetric`, `BERTScoreMetric`, `MeteorMetric`, and `SBERTMetric`, raising a clear `ValueError` instead of a raw `ZeroDivisionError`.
- Defer metric construction in `AdvancedAttackMetric` to first use in `calculate()` instead of eagerly loading every model in `__init__`; duplicate choice names no longer double-instantiate.
- Make `achoices` a property derived from `selected_metrics` so it can't go stale after `add_metric()`.
- Unify invalid-input handling on `ValueError` in both `__init__` and `add_metric()`, and drop unnecessary throwaway dict allocations.
- Drop the unrelated `venv/` line from `.gitignore` added in #802 (net no-op vs `master`).
- Fix `test_metric_ad_hoc`, which was silently broken: it exercised the default `choices=["use"]` metric on empty results (`ZeroDivisionError`) and asserted a key (`"perplexity"`) that `calculate()` never returns.

## Test plan
- [x] `black --check` passes on all touched files
- [x] `python -m pytest tests/test_metric_api.py -v` — all 7 tests pass, including the two end-to-end tests that run a real `Attacker` against SST2 (`test_use`, `test_metric_recipe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)