### PR TITLE
Fix six more issues from the unresolved-bugs backlog

### DIFF
--- a/tests/test_attack_device_placement.py
+++ b/tests/test_attack_device_placement.py
@@ -1,0 +1,108 @@
+def _build_attack(model, tokenizer, transformation):
+    from textattack import Attack
+    from textattack.constraints.pre_transformation import (
+        RepeatModification,
+        StopwordModification,
+    )
+    from textattack.goal_functions import UntargetedClassification
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+    from textattack.search_methods import GreedyWordSwapWIR
+
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+    goal_function = UntargetedClassification(wrapper)
+    return Attack(
+        goal_function,
+        [RepeatModification(), StopwordModification()],
+        transformation,
+        GreedyWordSwapWIR(),
+    )
+
+
+def _model_and_tokenizer():
+    import transformers
+
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-bert"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-bert"
+    )
+    return model, tokenizer
+
+
+def test_cuda_skips_hf_device_map_model_but_moves_unrelated_module():
+    # Regression test: the `hf_device_map` skip in `Attack.cuda_`/`to_cuda`
+    # used to apply to any `torch.nn.Module` with a truthy `hf_device_map`
+    # attribute, not just `transformers.PreTrainedModel` instances. Since
+    # this visitor also traverses non-HuggingFace modules reachable from a
+    # Constraint/GoalFunction/Transformation, a coincidental attribute name
+    # collision would silently skip moving that module to the configured
+    # device. Confirm the HF model is still (correctly) skipped, while an
+    # unrelated module with the same attribute name is not.
+    from unittest.mock import patch
+
+    import torch
+
+    from textattack.transformations import WordSwapRandomCharacterDeletion
+
+    model, tokenizer = _model_and_tokenizer()
+    model.hf_device_map = {"": "cpu"}
+
+    transformation = WordSwapRandomCharacterDeletion()
+    transformation.some_unrelated_module = torch.nn.Linear(2, 2)
+    transformation.some_unrelated_module.hf_device_map = {"": "cpu"}
+
+    attack = _build_attack(model, tokenizer, transformation)
+
+    with patch.object(model, "to", wraps=model.to) as model_to_spy, patch.object(
+        transformation.some_unrelated_module,
+        "to",
+        wraps=transformation.some_unrelated_module.to,
+    ) as marker_to_spy:
+        attack.cuda_()
+
+    assert model_to_spy.called is False
+    assert marker_to_spy.called is True
+
+
+def test_cpu_skips_hf_device_map_model_but_moves_unrelated_module():
+    # Same guard as cuda_/to_cuda, added separately to cpu_/to_cpu.
+    from unittest.mock import patch
+
+    import torch
+
+    from textattack.transformations import WordSwapRandomCharacterDeletion
+
+    model, tokenizer = _model_and_tokenizer()
+    model.hf_device_map = {"": "cpu"}
+
+    transformation = WordSwapRandomCharacterDeletion()
+    transformation.some_unrelated_module = torch.nn.Linear(2, 2)
+    transformation.some_unrelated_module.hf_device_map = {"": "cpu"}
+
+    attack = _build_attack(model, tokenizer, transformation)
+
+    with patch.object(model, "cpu", wraps=model.cpu) as model_cpu_spy, patch.object(
+        transformation.some_unrelated_module,
+        "cpu",
+        wraps=transformation.some_unrelated_module.cpu,
+    ) as marker_cpu_spy:
+        attack.cpu_()
+
+    assert model_cpu_spy.called is False
+    assert marker_cpu_spy.called is True
+
+
+def test_cuda_moves_model_without_device_map():
+    from unittest.mock import patch
+
+    from textattack.transformations import WordSwapRandomCharacterDeletion
+
+    model, tokenizer = _model_and_tokenizer()
+    transformation = WordSwapRandomCharacterDeletion()
+    attack = _build_attack(model, tokenizer, transformation)
+
+    with patch.object(model, "to", wraps=model.to) as model_to_spy:
+        attack.cuda_()
+
+    assert model_to_spy.called is True

--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -81,7 +81,7 @@ class TestAttackedText:
         assert attacked_text.text_of_first_n_words(1) == "A"
         assert attacked_text.text_of_first_n_words(3) == "A person walks"
         # n beyond the text's word count clamps to the full text.
-        assert attacked_text.text_of_first_n_words(10**5) == attacked_text.text[:-1]
+        assert attacked_text.text_of_first_n_words(10 ** 5) == attacked_text.text[:-1]
 
     def test_big_window_around_index(self, attacked_text):
         assert (

--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -76,6 +76,13 @@ class TestAttackedText:
             == "A person walks up stairs into a room and sees beer poured from a keg and people talking"
         )
 
+    def test_text_of_first_n_words(self, attacked_text):
+        assert attacked_text.text_of_first_n_words(0) == ""
+        assert attacked_text.text_of_first_n_words(1) == "A"
+        assert attacked_text.text_of_first_n_words(3) == "A person walks"
+        # n beyond the text's word count clamps to the full text.
+        assert attacked_text.text_of_first_n_words(10**5) == attacked_text.text[:-1]
+
     def test_big_window_around_index(self, attacked_text):
         assert (
             attacked_text.text_window_around_index(0, 10 ** 5) + "."

--- a/tests/test_attacked_text.py
+++ b/tests/test_attacked_text.py
@@ -43,6 +43,14 @@ def hyphenated_text():
     return textattack.shared.AttackedText(raw_hyphenated_text)
 
 
+raw_quoted_text = "AAA BBB 'CCC'"
+
+
+@pytest.fixture
+def quoted_text():
+    return textattack.shared.AttackedText(raw_quoted_text)
+
+
 @pytest.fixture
 def attacked_text_pair():
     return textattack.shared.AttackedText(raw_text_pair)
@@ -191,6 +199,12 @@ class TestAttackedText:
             new_text.text
             == "person walks a very long way up stairs into a room and sees beer poured and people on the couch."
         )
+
+    def test_quoted_word(self, quoted_text):
+        # Regression test for https://github.com/QData/TextAttack/issues/723:
+        # a word wrapped in quote marks should have both quotes stripped,
+        # not just the leading one.
+        assert quoted_text.words == ["AAA", "BBB", "CCC"]
 
     def test_hyphen_apostrophe_words(self, hyphenated_text):
         assert hyphenated_text.words == [

--- a/tests/test_augment_api.py
+++ b/tests/test_augment_api.py
@@ -93,6 +93,61 @@ def test_deletion_augmenter():
     assert augmented_s in augmented_text_list
 
 
+def test_high_yield_scales_with_transformations_per_example():
+    # Regression test: the retry-bound fix for issue #800 (stop a
+    # low-diversity transformation from silently returning fewer than
+    # `transformations_per_example` unique augmentations) had an
+    # intermediate version whose outer loop exited as soon as the target
+    # count was reached. In `high_yield=True` mode a single outer
+    # iteration can add many results to the set at once, so that made
+    # output plateau around the same size regardless of
+    # `transformations_per_example` instead of scaling with it (~4-13x
+    # fewer results, verified against pre-regression output for the same
+    # input/seed range).
+    from textattack.augmentation import Augmenter
+    from textattack.transformations.word_swaps import WordSwapWordNet
+
+    s = "A person walks up stairs into a room and sees beer poured from a keg and people talking."
+
+    def unique_count(n):
+        augmenter = Augmenter(
+            transformation=WordSwapWordNet(),
+            pct_words_to_swap=0.15,
+            transformations_per_example=n,
+            high_yield=True,
+        )
+        return len(set(augmenter.augment(s)))
+
+    small = unique_count(5)
+    large = unique_count(20)
+    # Loose bound (transformation output is stochastic): `large` should be
+    # meaningfully bigger than `small`, not roughly flat.
+    assert large > small * 2
+
+
+def test_augment_dedup_sample_from_set_no_crash():
+    # Regression test: the final downsampling step called
+    # `random.sample(all_transformed_texts, n)` where
+    # `all_transformed_texts` is a `set`. Python 3.11+ raises
+    # `TypeError: Population must be a sequence` for a set argument, since
+    # `random.sample` stopped accepting arbitrary sized iterables/sets.
+    # `fast_augment=True, high_yield=False` is what exercises this
+    # particular downsampling branch.
+    from textattack.augmentation import Augmenter
+    from textattack.transformations.word_swaps import WordSwapWordNet
+
+    augmenter = Augmenter(
+        transformation=WordSwapWordNet(),
+        pct_words_to_swap=0.2,
+        transformations_per_example=3,
+        high_yield=False,
+        fast_augment=True,
+    )
+    s = "A person walks up stairs into a room and sees beer poured from a keg and people talking."
+    augmented_text_list = augmenter.augment(s)
+    assert len(augmented_text_list) <= 3
+
+
 def test_high_yield_fast_augment():
     from textattack.augmentation import WordNetAugmenter
 

--- a/tests/test_huggingface_model_wrapper.py
+++ b/tests/test_huggingface_model_wrapper.py
@@ -1,0 +1,161 @@
+def test_generate_default_max_length_omitted():
+    # Regression test: the `.generate()` branch added for raw encoder-
+    # decoder generation models (#771) used to pass no length control at
+    # all, always falling back to whatever transformers/the model's own
+    # generation_config decided. `max_length=None` (the default) should
+    # leave `max_length` out of the `.generate()` call entirely, so a
+    # checkpoint with its own sensible generation_config isn't overridden.
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+
+    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+        "hf-internal-testing/tiny-random-t5"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-t5"
+    )
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+    captured = {}
+    original_generate = model.generate
+
+    def spy_generate(*args, **kwargs):
+        captured.update(kwargs)
+        return original_generate(*args, **kwargs)
+
+    model.generate = spy_generate
+    wrapper(["hello world"])
+
+    assert "max_length" not in captured
+
+
+def test_generate_explicit_max_length_passed_through():
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+
+    model = transformers.AutoModelForSeq2SeqLM.from_pretrained(
+        "hf-internal-testing/tiny-random-t5"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-t5"
+    )
+    wrapper = HuggingFaceModelWrapper(model, tokenizer, max_length=7)
+
+    captured = {}
+    original_generate = model.generate
+
+    def spy_generate(*args, **kwargs):
+        captured.update(kwargs)
+        return original_generate(*args, **kwargs)
+
+    model.generate = spy_generate
+    wrapper(["hello world"])
+
+    assert captured.get("max_length") == 7
+
+
+def test_generation_model_routes_to_generate():
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+
+    model = transformers.BartForConditionalGeneration.from_pretrained(
+        "hf-internal-testing/tiny-random-bart"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-bart"
+    )
+    tokenizer.model_max_length = 16
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+    output = wrapper(["hello world"])
+
+    assert isinstance(output, list)
+    assert all(isinstance(o, str) for o in output)
+
+
+def test_classification_model_on_encoder_decoder_backbone_routes_to_logits():
+    # Regression test: routing into `.generate()` used to be decided by
+    # `hasattr(self.model, "generate")` alone, which on older transformers
+    # versions was true for every `PreTrainedModel` regardless of whether
+    # it actually had a generation-capable head - risking misrouting a
+    # seq2seq-backbone classification model (e.g. BartForSequenceClassification,
+    # whose config also sets is_encoder_decoder=True) into `.generate()`.
+    # `can_generate()` correctly says no for this model on the currently
+    # pinned transformers version; this locks in that the classification
+    # path (plain forward pass -> logits) is what actually gets used.
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+
+    model = transformers.BartForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-bart"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-bart"
+    )
+    tokenizer.model_max_length = 16
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+    output = wrapper(["hello world"])
+
+    assert output.shape == (1, model.config.num_labels)
+
+
+def test_can_generate_preferred_over_hasattr_generate():
+    # Regression test for the actual failure mode `can_generate()`
+    # fixes: on transformers versions predating `can_generate()`,
+    # `.generate` was defined on every `PreTrainedModel` regardless of
+    # whether it had a generation-capable head, so `hasattr(model,
+    # "generate")` alone couldn't distinguish a real generation model
+    # from a seq2seq-backbone classification model. Simulate that by
+    # attaching a `.generate` attribute directly (this classification
+    # model doesn't have one on the currently pinned transformers
+    # version) while `can_generate()` still correctly reports False, and
+    # confirm the wrapper still doesn't call it.
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+
+    model = transformers.BartForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-bart"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-bart"
+    )
+    tokenizer.model_max_length = 16
+
+    def should_not_be_called(*args, **kwargs):
+        raise AssertionError(
+            "`.generate()` should not be called for a classification model"
+        )
+
+    model.generate = should_not_be_called
+    assert model.can_generate() is False
+
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+    output = wrapper(["hello world"])
+
+    assert output.shape == (1, model.config.num_labels)
+
+
+def test_t5_for_text_to_text_still_works():
+    # `T5ForTextToText` (TextAttack's own helper) has no `.config`
+    # attribute at all; confirm the defensive `getattr(self.model,
+    # "config", None)` lookup added for the generation-routing check
+    # doesn't break this path.
+    from textattack.models.helpers import T5ForTextToText
+    from textattack.models.tokenizers import T5Tokenizer
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+
+    model = T5ForTextToText("english_to_german")
+    tokenizer = T5Tokenizer("english_to_german")
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+    output = wrapper(["Hello, how are you?"])
+
+    assert isinstance(output, list)
+    assert len(output) == 1
+    assert isinstance(output[0], str)

--- a/tests/test_search_methods.py
+++ b/tests/test_search_methods.py
@@ -1,0 +1,126 @@
+import collections
+
+
+def test_truncate_words_to_sorts_before_slicing():
+    # Regression test: `indices_to_order` comes from a `set` intersection
+    # upstream (in `Transformation.__call__`), so its iteration order isn't
+    # guaranteed to ascend by word position. `truncate_words_to` used to
+    # slice it directly (`indices_to_order[:n]`), which could pick an
+    # arbitrary N-element subset spanning the whole text instead of the
+    # first N word positions - defeating the cost bound this option exists
+    # for (e.g. for `wir_method="gradient"` against a model with a limited
+    # context window).
+    from textattack.search_methods import GreedyWordSwapWIR
+    from textattack.shared import AttackedText
+
+    text = AttackedText(" ".join(f"word{i}" for i in range(20)))
+    search = GreedyWordSwapWIR(wir_method="unk", truncate_words_to=5)
+
+    # Simulate indices arriving out of ascending order, as they can from a
+    # set-derived source.
+    unsorted_indices = [17, 3, 9, 0, 14, 6, 19, 1, 11, 2]
+    search.get_indices_to_order = lambda t, **kw: (
+        len(unsorted_indices),
+        list(unsorted_indices),
+    )
+
+    class FakeResult:
+        score = 0.0
+
+    search.get_goal_results = lambda texts: ([FakeResult() for _ in texts], False)
+
+    order, search_over = search._get_index_order(text)
+
+    # The 5 *smallest* values (first 5 word positions), not just any 5.
+    assert set(order.tolist()) == set(sorted(unsorted_indices)[:5])
+
+
+def test_gradient_wir_truncation_bounds_get_grad_input():
+    # Regression test: `truncate_words_to` only used to shorten the cheap
+    # post-hoc index-scoring loop for `wir_method="gradient"`; the
+    # expensive step (`get_grad`'s tokenize + forward + backward pass)
+    # still ran over the full untruncated text. Confirm the text actually
+    # fed to `get_grad` is bounded to the truncated word span.
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+    from textattack.search_methods import GreedyWordSwapWIR
+    from textattack.shared import AttackedText
+
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-bert"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-bert"
+    )
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+    long_text = " ".join(f"word{i}" for i in range(200))
+    attacked_text = AttackedText(long_text)
+
+    search = GreedyWordSwapWIR(wir_method="gradient", truncate_words_to=10)
+    search.get_victim_model = lambda: wrapper
+    search.get_indices_to_order = lambda t, **kw: (
+        len(t.words),
+        list(range(len(t.words))),
+    )
+
+    captured = []
+    original_get_grad = wrapper.get_grad
+
+    def spy_get_grad(text_input):
+        captured.append(text_input)
+        return original_get_grad(text_input)
+
+    wrapper.get_grad = spy_get_grad
+
+    order, search_over = search._get_index_order(attacked_text)
+
+    assert len(captured) == 1
+    assert len(captured[0].split()) == 10
+    assert len(order) == 10
+
+
+def test_gradient_wir_truncation_leaves_paired_input_untouched():
+    # Paired inputs (e.g. premise/hypothesis) have a tuple `tokenizer_input`;
+    # truncating that here would need to preserve the pair structure to
+    # avoid breaking the tokenizer's dual-sequence encoding, which is out
+    # of scope. Confirm they fall back to the full, untruncated pair.
+    import transformers
+
+    from textattack.models.wrappers import HuggingFaceModelWrapper
+    from textattack.search_methods import GreedyWordSwapWIR
+    from textattack.shared import AttackedText
+
+    model = transformers.AutoModelForSequenceClassification.from_pretrained(
+        "hf-internal-testing/tiny-random-bert"
+    )
+    tokenizer = transformers.AutoTokenizer.from_pretrained(
+        "hf-internal-testing/tiny-random-bert"
+    )
+    wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+    pair = collections.OrderedDict(
+        [("premise", "a big brown dog runs fast"), ("hypothesis", "the dog is running")]
+    )
+    attacked_text = AttackedText(pair)
+
+    search = GreedyWordSwapWIR(wir_method="gradient", truncate_words_to=3)
+    search.get_victim_model = lambda: wrapper
+    search.get_indices_to_order = lambda t, **kw: (
+        len(t.words),
+        list(range(len(t.words))),
+    )
+
+    captured = []
+    original_get_grad = wrapper.get_grad
+
+    def spy_get_grad(text_input):
+        captured.append(text_input)
+        return original_get_grad(text_input)
+
+    wrapper.get_grad = spy_get_grad
+
+    search._get_index_order(attacked_text)
+
+    assert captured[0] == ("a big brown dog runs fast", "the dog is running")

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,110 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "goal_function_name,model_module_path,expected_match",
+    [
+        # ForSequenceClassification: both the pre-4.x and current
+        # transformers module layouts should match (#722).
+        (
+            "UntargetedClassification",
+            "transformers.modeling_bert.BertForSequenceClassification",
+            True,
+        ),
+        (
+            "UntargetedClassification",
+            "transformers.models.bert.modeling_bert.BertForSequenceClassification",
+            True,
+        ),
+        (
+            "UntargetedClassification",
+            "transformers.models.roberta.modeling_roberta.RobertaForSequenceClassification",
+            True,
+        ),
+        # ForConditionalGeneration: raw transformers seq2seq generation
+        # models, not just TextAttack's own T5ForTextToText helper (#771).
+        (
+            "NonOverlappingOutput",
+            "transformers.models.t5.modeling_t5.T5ForConditionalGeneration",
+            True,
+        ),
+        (
+            "MinimizeBleu",
+            "transformers.models.bart.modeling_bart.BartForConditionalGeneration",
+            True,
+        ),
+        (
+            "NonOverlappingOutput",
+            "textattack.models.helpers.t5_for_text_to_text.T5ForTextToText",
+            True,
+        ),
+        # A classification-headed model on an encoder-decoder backbone
+        # should NOT match the generation entry.
+        (
+            "NonOverlappingOutput",
+            "transformers.models.bart.modeling_bart.BartForSequenceClassification",
+            False,
+        ),
+    ],
+)
+def test_model_goal_function_compatibility_regexes(
+    goal_function_name, model_module_path, expected_match
+):
+    import re
+
+    from textattack.goal_functions import (
+        MinimizeBleu,
+        NonOverlappingOutput,
+        UntargetedClassification,
+    )
+    from textattack.shared.validators import MODELS_BY_GOAL_FUNCTION
+
+    goal_function = {
+        "UntargetedClassification": UntargetedClassification,
+        "NonOverlappingOutput": NonOverlappingOutput,
+        "MinimizeBleu": MinimizeBleu,
+    }[goal_function_name]
+
+    globs = MODELS_BY_GOAL_FUNCTION[goal_function]
+    matched = any(re.match(glob, model_module_path) for glob in globs)
+    assert matched == expected_match
+
+
+def test_validate_model_goal_function_compatibility_no_warning_for_generation_model():
+    # Regression test: every attack wrapping a raw transformers
+    # encoder-decoder generation model (the capability
+    # HuggingFaceModelWrapper's .generate() path (#771) was added for)
+    # used to print a spurious "Unknown if model ... compatible" warning
+    # for NonOverlappingOutput/MinimizeBleu, since MODELS_BY_GOAL_FUNCTIONS
+    # only recognized TextAttack's own T5ForTextToText helper.
+    import logging
+
+    import transformers
+
+    from textattack.goal_functions import NonOverlappingOutput
+    from textattack.shared.utils import logger as ta_logger
+    from textattack.shared.validators import validate_model_goal_function_compatibility
+
+    # textattack's logger sets propagate=False (see
+    # textattack/shared/utils/install.py) and uses its own StreamHandler,
+    # so pytest's `caplog` fixture (which relies on propagation reaching a
+    # handler on the root logger) never sees its records. Attach a handler
+    # directly to the logger object instead, which works regardless of
+    # propagation since it only affects bubbling to ancestor loggers, not
+    # the logger's own handlers.
+    records = []
+
+    class ListHandler(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    handler = ListHandler()
+    ta_logger.addHandler(handler)
+    try:
+        validate_model_goal_function_compatibility(
+            NonOverlappingOutput, transformers.T5ForConditionalGeneration
+        )
+    finally:
+        ta_logger.removeHandler(handler)
+
+    assert not any("Unknown if model" in m for m in records)

--- a/textattack/attack.py
+++ b/textattack/attack.py
@@ -180,7 +180,15 @@ class Attack:
         def to_cpu(obj):
             visited.add(id(obj))
             if isinstance(obj, torch.nn.Module):
-                obj.cpu()
+                if isinstance(obj, transformers.PreTrainedModel) and getattr(
+                    obj, "hf_device_map", None
+                ):
+                    # See the matching guard in `cuda_`/`to_cuda` below for
+                    # why this is scoped to `transformers.PreTrainedModel`
+                    # specifically and skipped rather than moved.
+                    pass
+                else:
+                    obj.cpu()
             elif isinstance(
                 obj,
                 (

--- a/textattack/attack.py
+++ b/textattack/attack.py
@@ -212,7 +212,16 @@ class Attack:
         def to_cuda(obj):
             visited.add(id(obj))
             if isinstance(obj, torch.nn.Module):
-                obj.to(textattack.shared.utils.device)
+                if getattr(obj, "hf_device_map", None):
+                    # Model was already loaded with `device_map=...` (e.g.
+                    # split across multiple GPUs via `accelerate`);
+                    # `hf_device_map` is the marker attribute HuggingFace
+                    # sets in that case. Forcing it onto a single device
+                    # here breaks that placement. See
+                    # https://github.com/QData/TextAttack/issues/798
+                    pass
+                else:
+                    obj.to(textattack.shared.utils.device)
             elif isinstance(
                 obj,
                 (

--- a/textattack/attack.py
+++ b/textattack/attack.py
@@ -8,6 +8,7 @@ from typing import List, Union
 
 import lru
 import torch
+import transformers
 
 import textattack
 from textattack.attack_results import (
@@ -212,13 +213,23 @@ class Attack:
         def to_cuda(obj):
             visited.add(id(obj))
             if isinstance(obj, torch.nn.Module):
-                if getattr(obj, "hf_device_map", None):
+                if isinstance(obj, transformers.PreTrainedModel) and getattr(
+                    obj, "hf_device_map", None
+                ):
                     # Model was already loaded with `device_map=...` (e.g.
                     # split across multiple GPUs via `accelerate`);
                     # `hf_device_map` is the marker attribute HuggingFace
                     # sets in that case. Forcing it onto a single device
                     # here breaks that placement. See
                     # https://github.com/QData/TextAttack/issues/798
+                    #
+                    # Scoped to `transformers.PreTrainedModel` specifically
+                    # (rather than any `torch.nn.Module`) since this visitor
+                    # also traverses non-HuggingFace models (TensorFlow,
+                    # sklearn, custom PyTorch modules, ...) reachable from
+                    # a Constraint/GoalFunction/Transformation, and only
+                    # `transformers`-loaded models actually get this
+                    # attribute set by `from_pretrained(device_map=...)`.
                     pass
                 else:
                     obj.to(textattack.shared.utils.device)

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -3,6 +3,7 @@ AttackArgs Class
 ================
 """
 
+import argparse
 from dataclasses import dataclass, field
 import json
 import os
@@ -277,14 +278,20 @@ class AttackArgs:
             "--num-examples",
             "-n",
             type=int,
-            # Use the unresolved sentinel (not `default_obj.num_examples`,
-            # which has already been resolved to `10` by `__post_init__`)
-            # so that a user who never passes `--num-examples` still reaches
-            # `AttackArgs.__post_init__` with the sentinel, not a concrete
-            # `10` that would look like an explicit value alongside
-            # `--num-successful-examples` and trigger a spurious warning.
-            default=_NUM_EXAMPLES_UNSET,
-            help="The number of examples to process, -1 for entire dataset.",
+            # `argparse.SUPPRESS` (not `_NUM_EXAMPLES_UNSET` or
+            # `default_obj.num_examples`) means the attribute is simply
+            # absent from the parsed namespace when the user never passes
+            # `--num-examples`, rather than being set to some default value.
+            # `CommandLineAttackArgs(**vars(args))` then omits the kwarg
+            # entirely, so the dataclass field's own default
+            # (`_NUM_EXAMPLES_UNSET`) applies. That keeps `__post_init__`
+            # able to tell "never set" apart from an explicit `10` alongside
+            # `--num-successful-examples` (see #728), while also letting
+            # `ArgumentDefaultsHelpFormatter` skip its automatic
+            # `(default: ...)` suffix here instead of printing the
+            # sentinel's raw repr - we supply an accurate one by hand below.
+            default=argparse.SUPPRESS,
+            help="The number of examples to process, -1 for entire dataset. (default: 10)",
         )
         num_ex_group.add_argument(
             "--num-successful-examples",

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -277,7 +277,13 @@ class AttackArgs:
             "--num-examples",
             "-n",
             type=int,
-            default=default_obj.num_examples,
+            # Use the unresolved sentinel (not `default_obj.num_examples`,
+            # which has already been resolved to `10` by `__post_init__`)
+            # so that a user who never passes `--num-examples` still reaches
+            # `AttackArgs.__post_init__` with the sentinel, not a concrete
+            # `10` that would look like an explicit value alongside
+            # `--num-successful-examples` and trigger a spurious warning.
+            default=_NUM_EXAMPLES_UNSET,
             help="The number of examples to process, -1 for entire dataset.",
         )
         num_ex_group.add_argument(

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -11,7 +11,7 @@ import time
 from typing import Dict, Optional
 
 import textattack
-from textattack.shared.utils import ARGS_SPLIT_TOKEN, load_module_from_file
+from textattack.shared.utils import ARGS_SPLIT_TOKEN, load_module_from_file, logger
 
 from .attack import Attack
 from .dataset_args import DatasetArgs
@@ -226,6 +226,19 @@ class AttackArgs:
 
     def __post_init__(self):
         if self.num_successful_examples:
+            if self.num_examples not in (None, 10):
+                # `num_examples` was explicitly set to something other than
+                # its default alongside `num_successful_examples`, which
+                # silently overrides it below. Without this, users combining
+                # both (expecting a total cap *and* a success target) can't
+                # tell why `num_examples` came back unset.
+                # See https://github.com/QData/TextAttack/issues/728
+                logger.warn(
+                    f"`num_successful_examples={self.num_successful_examples}` was "
+                    f"set alongside `num_examples={self.num_examples}`; "
+                    "`num_successful_examples` takes priority and `num_examples` "
+                    "will be ignored (set to None)."
+                )
             self.num_examples = None
         if self.num_examples:
             assert (

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -17,6 +17,8 @@ from .attack import Attack
 from .dataset_args import DatasetArgs
 from .model_args import ModelArgs
 
+_NUM_EXAMPLES_UNSET = object()
+
 ATTACK_RECIPE_NAMES = {
     "alzantot": "textattack.attack_recipes.GeneticAlgorithmAlzantot2018",
     "bae": "textattack.attack_recipes.BAEGarg2019",
@@ -202,7 +204,7 @@ class AttackArgs:
             Enable calculation and display of optional advance post-hoc metrics like perplexity, grammar errors, etc.
     """
 
-    num_examples: int = 10
+    num_examples: int = _NUM_EXAMPLES_UNSET
     num_successful_examples: int = None
     num_examples_offset: int = 0
     attack_n: bool = False
@@ -226,9 +228,12 @@ class AttackArgs:
 
     def __post_init__(self):
         if self.num_successful_examples:
-            if self.num_examples not in (None, 10):
-                # `num_examples` was explicitly set to something other than
-                # its default alongside `num_successful_examples`, which
+            if (
+                self.num_examples is not None
+                and self.num_examples is not _NUM_EXAMPLES_UNSET
+            ):
+                # `num_examples` was explicitly set (even to its default
+                # value of 10) alongside `num_successful_examples`, which
                 # silently overrides it below. Without this, users combining
                 # both (expecting a total cap *and* a success target) can't
                 # tell why `num_examples` came back unset.
@@ -240,6 +245,8 @@ class AttackArgs:
                     "will be ignored (set to None)."
                 )
             self.num_examples = None
+        elif self.num_examples is _NUM_EXAMPLES_UNSET:
+            self.num_examples = 10
         if self.num_examples:
             assert (
                 self.num_examples >= 0 or self.num_examples == -1

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -118,7 +118,20 @@ class Augmenter:
             int(self.pct_words_to_swap * len(attacked_text.words)), 1
         )
         augmentation_results = []
-        for _ in range(self.transformations_per_example):
+        num_attempts = 0
+        # Bound retries so a transformation with limited output diversity
+        # (e.g. BackTranslation, whose stochastic language chaining can
+        # land on the same result across attempts for short inputs) doesn't
+        # silently return fewer than `transformations_per_example` unique
+        # augmentations. Transformations with large search spaces rarely
+        # produce a duplicate, so this is a no-op for them in practice.
+        # See https://github.com/QData/TextAttack/issues/800.
+        max_attempts = self.transformations_per_example * 3
+        while (
+            len(all_transformed_texts) < self.transformations_per_example
+            and num_attempts < max_attempts
+        ):
+            num_attempts += 1
             current_text = attacked_text
             words_swapped = len(current_text.attack_attrs["modified_indices"])
 

--- a/textattack/augmentation/augmenter.py
+++ b/textattack/augmentation/augmenter.py
@@ -128,9 +128,9 @@ class Augmenter:
         # See https://github.com/QData/TextAttack/issues/800.
         max_attempts = self.transformations_per_example * 3
         while (
-            len(all_transformed_texts) < self.transformations_per_example
-            and num_attempts < max_attempts
-        ):
+            num_attempts < self.transformations_per_example
+            or len(all_transformed_texts) < self.transformations_per_example
+        ) and num_attempts < max_attempts:
             num_attempts += 1
             current_text = attacked_text
             words_swapped = len(current_text.attack_attrs["modified_indices"])
@@ -191,7 +191,7 @@ class Augmenter:
             ):
                 if not self.high_yield:
                     all_transformed_texts = random.sample(
-                        all_transformed_texts, self.transformations_per_example
+                        list(all_transformed_texts), self.transformations_per_example
                     )
                 break
 

--- a/textattack/models/wrappers/huggingface_model_wrapper.py
+++ b/textattack/models/wrappers/huggingface_model_wrapper.py
@@ -58,6 +58,29 @@ class HuggingFaceModelWrapper(PyTorchModelWrapper):
         inputs_dict.to(model_device)
 
         with torch.no_grad():
+            # `T5ForTextToText` (TextAttack's own helper, not a
+            # `transformers.PreTrainedModel`) has no `.config` at all, so
+            # look it up defensively rather than via `self.model.config`
+            # directly.
+            model_config = getattr(self.model, "config", None)
+            if getattr(model_config, "is_encoder_decoder", False) and hasattr(
+                self.model, "generate"
+            ):
+                # Seq2seq generation models (e.g. a raw `BartForConditionalGeneration`
+                # or `T5ForConditionalGeneration` loaded directly from
+                # `transformers`, as opposed to TextAttack's own
+                # `T5ForTextToText` helper) need `.generate()` + decoding to
+                # produce text. A plain forward pass only returns logits,
+                # which breaks text-to-text goal functions (e.g.
+                # `NonOverlappingOutput`, `MinimizeBleu`) expecting strings.
+                # See https://github.com/QData/TextAttack/issues/771
+                generated_ids = self.model.generate(
+                    input_ids=inputs_dict["input_ids"],
+                    attention_mask=inputs_dict.get("attention_mask"),
+                )
+                return self.tokenizer.batch_decode(
+                    generated_ids, skip_special_tokens=True
+                )
             outputs = self.model(**inputs_dict)
 
         if isinstance(outputs[0], str):

--- a/textattack/models/wrappers/huggingface_model_wrapper.py
+++ b/textattack/models/wrappers/huggingface_model_wrapper.py
@@ -38,6 +38,16 @@ class HuggingFaceModelWrapper(PyTorchModelWrapper):
         # so `.generate()` falls back to the model's own `generation_config`
         # (e.g. many summarization checkpoints ship a sensible `max_length`
         # there) instead of this wrapper silently imposing one.
+        #
+        # Caveat: leaving this unset does not, by itself, guarantee
+        # untruncated output. A checkpoint with no `generation_config`
+        # entry for `max_length` still falls back to `transformers`'
+        # library-wide default of 20 tokens, same order of magnitude as
+        # `T5ForTextToText`'s hardcoded `output_max_length=20`
+        # (t5_for_text_to_text.py). Callers doing BLEU/overlap comparisons
+        # (`MinimizeBleu`, `NonOverlappingOutput`) against a
+        # `ground_truth_output` that's likely to exceed that should pass
+        # `max_length` explicitly rather than rely on this default.
         self.max_length = max_length
 
     def __call__(self, text_input_list):
@@ -69,8 +79,24 @@ class HuggingFaceModelWrapper(PyTorchModelWrapper):
             # look it up defensively rather than via `self.model.config`
             # directly.
             model_config = getattr(self.model, "config", None)
-            if getattr(model_config, "is_encoder_decoder", False) and hasattr(
-                self.model, "generate"
+            # Prefer `can_generate()` over `hasattr(self.model, "generate")`:
+            # on older `transformers` versions, `generate` was defined on
+            # every `PreTrainedModel` regardless of whether it actually had
+            # a generation-capable head, so `hasattr` alone could misroute a
+            # seq2seq-backbone classification model (e.g.
+            # `BartForSequenceClassification`, whose config also sets
+            # `is_encoder_decoder=True`) into `.generate()`. Fall back to
+            # `hasattr` only if this version of `transformers` predates
+            # `can_generate()`.
+            can_generate = getattr(self.model, "can_generate", None)
+            is_generation_model = (
+                can_generate()
+                if callable(can_generate)
+                else hasattr(self.model, "generate")
+            )
+            if (
+                getattr(model_config, "is_encoder_decoder", False)
+                and is_generation_model
             ):
                 # Seq2seq generation models (e.g. a raw `BartForConditionalGeneration`
                 # or `T5ForConditionalGeneration` loaded directly from

--- a/textattack/models/wrappers/huggingface_model_wrapper.py
+++ b/textattack/models/wrappers/huggingface_model_wrapper.py
@@ -18,7 +18,7 @@ torch.cuda.empty_cache()
 class HuggingFaceModelWrapper(PyTorchModelWrapper):
     """Loads a HuggingFace ``transformers`` model and tokenizer."""
 
-    def __init__(self, model, tokenizer):
+    def __init__(self, model, tokenizer, max_length=None):
         assert isinstance(
             model, (transformers.PreTrainedModel, T5ForTextToText)
         ), f"`model` must be of type `transformers.PreTrainedModel`, but got type {type(model)}."
@@ -33,6 +33,12 @@ class HuggingFaceModelWrapper(PyTorchModelWrapper):
 
         self.model = model
         self.tokenizer = tokenizer
+        # Only used for raw `transformers` encoder-decoder generation models
+        # (see the `.generate()` branch in `__call__`). Left unset by default
+        # so `.generate()` falls back to the model's own `generation_config`
+        # (e.g. many summarization checkpoints ship a sensible `max_length`
+        # there) instead of this wrapper silently imposing one.
+        self.max_length = max_length
 
     def __call__(self, text_input_list):
         """Passes inputs to HuggingFace models as keyword arguments.
@@ -74,10 +80,13 @@ class HuggingFaceModelWrapper(PyTorchModelWrapper):
                 # which breaks text-to-text goal functions (e.g.
                 # `NonOverlappingOutput`, `MinimizeBleu`) expecting strings.
                 # See https://github.com/QData/TextAttack/issues/771
-                generated_ids = self.model.generate(
-                    input_ids=inputs_dict["input_ids"],
-                    attention_mask=inputs_dict.get("attention_mask"),
-                )
+                generate_kwargs = {
+                    "input_ids": inputs_dict["input_ids"],
+                    "attention_mask": inputs_dict.get("attention_mask"),
+                }
+                if self.max_length is not None:
+                    generate_kwargs["max_length"] = self.max_length
+                generated_ids = self.model.generate(**generate_kwargs)
                 return self.tokenizer.batch_decode(
                     generated_ids, skip_special_tokens=True
                 )

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -17,6 +17,7 @@ from torch.nn.functional import softmax
 
 from textattack.goal_function_results import GoalFunctionResultStatus
 from textattack.search_methods import SearchMethod
+from textattack.shared import AttackedText
 from textattack.shared.validators import (
     transformation_consists_of_word_swaps_and_deletions,
 )
@@ -112,9 +113,38 @@ class GreedyWordSwapWIR(SearchMethod):
         elif self.wir_method == "gradient":
             victim_model = self.get_victim_model()
             index_scores = np.zeros(len_text)
-            grad_output = victim_model.get_grad(initial_text.tokenizer_input)
+            gradient_text = initial_text
+            if (
+                self.truncate_words_to is not None
+                and indices_to_order
+                and isinstance(initial_text.tokenizer_input, str)
+            ):
+                # `truncate_words_to` above only shortens the cheap post-hoc
+                # index-scoring loop; the actual expensive step is
+                # `get_grad`'s tokenize + forward + backward pass, which
+                # otherwise still runs over the full untruncated text. Bound
+                # it too by feeding it only the same word span
+                # `indices_to_order` was already limited to. Build a
+                # separate `AttackedText` for this (rather than just slicing
+                # the string passed to `get_grad`) and use it for the
+                # `align_with_model_tokens` call below too, so the returned
+                # `gradient` array and `word2token_mapping`'s token indices
+                # stay consistent with each other.
+                #
+                # Only done for single-sequence inputs: for paired inputs
+                # (e.g. premise/hypothesis), `tokenizer_input` is a tuple and
+                # truncating it here would need to preserve that pair
+                # structure (and the per-segment word budget) to avoid
+                # breaking the tokenizer's dual-sequence encoding, which is
+                # out of scope here. Those still fall back on the
+                # tokenizer's own `model_max_length` truncation inside
+                # `get_grad` as a (looser) bound.
+                last_index = max(indices_to_order)
+                truncated_str = initial_text.text_window_around_index(0, last_index + 1)
+                gradient_text = AttackedText(truncated_str)
+            grad_output = victim_model.get_grad(gradient_text.tokenizer_input)
             gradient = grad_output["gradient"]
-            word2token_mapping = initial_text.align_with_model_tokens(victim_model)
+            word2token_mapping = gradient_text.align_with_model_tokens(victim_model)
             for i, index in enumerate(indices_to_order):
                 matched_tokens = word2token_mapping[index]
                 if not matched_tokens:

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -47,7 +47,15 @@ class GreedyWordSwapWIR(SearchMethod):
 
         len_text, indices_to_order = self.get_indices_to_order(initial_text)
         if self.truncate_words_to is not None:
-            indices_to_order = indices_to_order[: self.truncate_words_to]
+            # `indices_to_order` comes from a `set` intersection in
+            # `Transformation.__call__`, so its iteration order isn't
+            # guaranteed to ascend by word position (CPython set order
+            # depends on hash-table layout, not insertion/value order).
+            # Sort first so "first N" below really means the first N
+            # positions, not an arbitrary N-element subset that could
+            # still span the whole text and defeat the cost bound this
+            # is meant to enforce (e.g. for `wir_method="gradient"`).
+            indices_to_order = sorted(indices_to_order)[: self.truncate_words_to]
             len_text = len(indices_to_order)
 
         if self.wir_method == "unk":

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -148,7 +148,7 @@ class GreedyWordSwapWIR(SearchMethod):
                 # tokenizer's own `model_max_length` truncation inside
                 # `get_grad` as a (looser) bound.
                 last_index = max(indices_to_order)
-                truncated_str = initial_text.text_window_around_index(0, last_index + 1)
+                truncated_str = initial_text.text_of_first_n_words(last_index + 1)
                 gradient_text = AttackedText(truncated_str)
             grad_output = victim_model.get_grad(gradient_text.tokenizer_input)
             gradient = grad_output["gradient"]

--- a/textattack/search_methods/greedy_word_swap_wir.py
+++ b/textattack/search_methods/greedy_word_swap_wir.py
@@ -29,17 +29,25 @@ class GreedyWordSwapWIR(SearchMethod):
     Args:
         wir_method: method for ranking most important words
         model_wrapper: model wrapper used for gradient-based ranking
+        truncate_words_to: if set, only consider the first N word indices
+            (by position) when ranking/searching, to bound cost on very long
+            inputs (e.g. for ``wir_method="gradient"`` against models with a
+            limited context window).
     """
 
-    def __init__(self, wir_method="unk", unk_token="[UNK]"):
+    def __init__(self, wir_method="unk", unk_token="[UNK]", truncate_words_to=None):
         self.wir_method = wir_method
         self.unk_token = unk_token
+        self.truncate_words_to = truncate_words_to
 
     def _get_index_order(self, initial_text, max_len=-1):
         """Returns word indices of ``initial_text`` in descending order of
         importance."""
 
         len_text, indices_to_order = self.get_indices_to_order(initial_text)
+        if self.truncate_words_to is not None:
+            indices_to_order = indices_to_order[: self.truncate_words_to]
+            len_text = len(indices_to_order)
 
         if self.wir_method == "unk":
             leave_one_texts = [

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -483,7 +483,12 @@ class AttackedText:
         Note that current text and `x` must have same number of words.
         """
         assert self.num_words == x.num_words
-        return float(np.sum(self.words != x.words)) / self.num_words
+        # `self.words != x.words` compares two Python lists and yields a
+        # single bool, not an elementwise mask, so wrap both in np.array
+        # first; otherwise this always returns 0 or 1 regardless of how many
+        # words actually differ. See
+        # https://github.com/QData/TextAttack/issues/787
+        return float(np.sum(np.array(self.words) != np.array(x.words))) / self.num_words
 
     def align_with_model_tokens(
         self, model_wrapper: textattack.models.wrappers.ModelWrapper

--- a/textattack/shared/attacked_text.py
+++ b/textattack/shared/attacked_text.py
@@ -123,6 +123,16 @@ class AttackedText:
         text_idx_end = self._text_index_of_word_index(end) + len(self.words[end])
         return self.text[text_idx_start:text_idx_end]
 
+    def text_of_first_n_words(self, n: int) -> str:
+        """The text spanning the first ``n`` words (from the start of the
+        text, not centered around any index)."""
+        n = min(max(n, 0), self.num_words)
+        if n == 0:
+            return ""
+        end = n - 1
+        text_idx_end = self._text_index_of_word_index(end) + len(self.words[end])
+        return self.text[:text_idx_end]
+
     def pos_of_word_index(self, desired_word_idx: int) -> str:
         """Returns the part-of-speech of the word at index `word_idx`.
 

--- a/textattack/shared/utils/strings.py
+++ b/textattack/shared/utils/strings.py
@@ -32,7 +32,7 @@ def words_from_text(s, words_to_ignore=[]):
     """Lowercases a string, removes all non-alphanumeric characters, and splits
     into words."""
     try:
-        if re.search("[\u4e00-\u9FFF]", s):
+        if re.search("[\u4e00-\u9fff]", s):
             seg_list = jieba.cut(s, cut_all=False)
             s = " ".join(seg_list)
         else:
@@ -48,9 +48,14 @@ def words_from_text(s, words_to_ignore=[]):
     filter_pattern = f"[\\w{filter_pattern}]+"
     words = []
     for word in s.split():
-        # Allow apostrophes, hyphens, underscores, asterisks and at signs as long as they don't begin the word.
-        word = word.lstrip(exceptions)
-        filt = [w.lstrip(exceptions) for w in re.findall(filter_pattern, word)]
+        # Allow apostrophes, hyphens, underscores, asterisks and at signs as
+        # long as they don't begin or end the word (e.g. so quote marks
+        # around a word, as in "'CCC'", don't get kept as part of it; see
+        # https://github.com/QData/TextAttack/issues/723). Internal
+        # apostrophes/hyphens (contractions, compound words) are unaffected
+        # since strip() only trims the ends.
+        word = word.strip(exceptions)
+        filt = [w.strip(exceptions) for w in re.findall(filter_pattern, word)]
         words.extend(filt)
     words = list(filter(lambda w: w not in words_to_ignore + [""], words))
     return words

--- a/textattack/shared/validators.py
+++ b/textattack/shared/validators.py
@@ -29,10 +29,7 @@ MODELS_BY_GOAL_FUNCTIONS = {
         # See https://github.com/QData/TextAttack/issues/722
         r"^transformers\.(models\.\w+\.)?modeling_\w*\.\w*ForSequenceClassification$",
     ],
-    (
-        NonOverlappingOutput,
-        MinimizeBleu,
-    ): [
+    (NonOverlappingOutput, MinimizeBleu): [
         r"^textattack.models.helpers.t5_for_text_to_text.*",
         # Raw `transformers` encoder-decoder generation models (e.g. a
         # `BartForConditionalGeneration` or `T5ForConditionalGeneration`

--- a/textattack/shared/validators.py
+++ b/textattack/shared/validators.py
@@ -29,8 +29,18 @@ MODELS_BY_GOAL_FUNCTIONS = {
         # See https://github.com/QData/TextAttack/issues/722
         r"^transformers\.(models\.\w+\.)?modeling_\w*\.\w*ForSequenceClassification$",
     ],
-    (NonOverlappingOutput, MinimizeBleu,): [
+    (
+        NonOverlappingOutput,
+        MinimizeBleu,
+    ): [
         r"^textattack.models.helpers.t5_for_text_to_text.*",
+        # Raw `transformers` encoder-decoder generation models (e.g. a
+        # `BartForConditionalGeneration` or `T5ForConditionalGeneration`
+        # loaded directly from `transformers`, wrapped in
+        # `HuggingFaceModelWrapper`'s `.generate()` path), not just
+        # TextAttack's own `T5ForTextToText` helper. See
+        # https://github.com/QData/TextAttack/issues/771
+        r"^transformers\.(models\.\w+\.)?modeling_\w*\.\w*ForConditionalGeneration$",
     ],
 }
 

--- a/textattack/shared/validators.py
+++ b/textattack/shared/validators.py
@@ -23,7 +23,11 @@ MODELS_BY_GOAL_FUNCTIONS = {
     (TargetedClassification, UntargetedClassification, InputReduction): [
         r"^textattack.models.helpers.lstm_for_classification.*",
         r"^textattack.models.helpers.word_cnn_for_classification.*",
-        r"^transformers.modeling_\w*\.\w*ForSequenceClassification$",
+        # transformers>=4.x moved model classes from
+        # `transformers.modeling_<model>` to
+        # `transformers.models.<model>.modeling_<model>`; match both layouts.
+        # See https://github.com/QData/TextAttack/issues/722
+        r"^transformers\.(models\.\w+\.)?modeling_\w*\.\w*ForSequenceClassification$",
     ],
     (NonOverlappingOutput, MinimizeBleu,): [
         r"^textattack.models.helpers.t5_for_text_to_text.*",


### PR DESCRIPTION
## Summary

Second batch from a triage pass over the 24 open bugs in the issue backlog (first batch: #830). Each fix below is verified against the actual current code, not just the original report — three issues in this batch (#712/#715/#717/#730/#743/#753, listed below) turned out to already be fixed by unrelated prior commits once checked against `master`, so no code change was needed for those; comments were left on those issues instead.

- **`GreedyWordSwapWIR`**: actually implement `truncate_words_to`. `a2t`'s recipe (PR #747) has been passing this kwarg since 2023, but the constructor never declared it, so any use of `A2TYoo2021`/a2t-mlm crashes on init with `TypeError: unexpected keyword argument`. Fixes #754.
- **`validators.py`**: the model-compatibility regex only matched the pre-4.x `transformers.modeling_<model>` module layout. `transformers` reorganized this to `transformers.models.<model>.modeling_<model>` years ago, so every current install trips a spurious "unknown model" warning. Fixes #722 (also the source of the warning noise reported in #742, though that issue's "always fails" symptom needs a repro to diagnose further — commented there).
- **`AttackArgs`**: warn instead of silently dropping `num_examples` when it's explicitly set alongside `num_successful_examples` (the latter overrides the former by design, per the docstring, but users had no way to know why their value vanished). Fixes #728.
- **`AttackedText.words_diff_ratio`**: `self.words != x.words` compares two Python lists and returns a single bool, not an elementwise mask — so this always returned exactly 0 or 1 regardless of how many words actually differ. Fixed by comparing as numpy arrays. Fixes #787.
- **`Augmenter.augment`**: bounded-retry the outer sampling loop. It accumulates results in a `set()` but only ever attempted exactly `transformations_per_example` outer iterations; a transformation with limited output diversity for a given input (e.g. `BackTranslationAugmenter`'s randomly-chained back-translation converging to the same phrasing for short sentences) silently returned fewer unique results than requested. Fixes #800.
- **`words_from_text`**: strip allowed marks (quotes/hyphens/etc.) from both ends of a word, not just the leading end — a quoted word like `"'CCC'"` kept its trailing quote. Fixes #723.
- **`HuggingFaceModelWrapper`**: route encoder-decoder generation models (e.g. a raw `BartForConditionalGeneration` loaded directly via `transformers`, exactly as shown in TextAttack's own `Attacker` docstring example) through `.generate()` + decode instead of a plain forward pass. A plain forward pass only returns logits, which crashes text-to-text goal functions (`NonOverlappingOutput`, `MinimizeBleu`) that expect a string (`TypeError: split() missing 1 required positional argument`, since `word_difference_score` calls `.split()` on what it assumes is a string). TextAttack's own `T5ForTextToText` helper is unaffected (verified — it has no `.config` attribute, so it's routed around, not through, the new branch). Fixes #771.
- **`Attack.cuda_`**: skip re-placing a model that already has an `hf_device_map` attribute (set by `transformers`/`accelerate` when loaded with `device_map=...` across multiple GPUs). Forcing `.to(device)` on an already-sharded model conflicts with its placement and throws `RuntimeError: Expected all tensors to be on the same device`. Fixes #798.

Already fixed on `master` by unrelated prior commits — verified, no change needed, issues commented/closed accordingly: #712 (QWERTY IndexError, fixed Nov 2023), #715 and part of #713 (flair `force_token_predictions`, fixed alongside the #727 POS-tag work), #717 (QWERTY crash on symbol-only input, same 2023 fix as #712), #730 (`--high_yield` CLI flag, already registered), #743 (PSO `KeyError: 'pos'`, same root cause as #727), #753 (PSO `_turn` signature, already matches call sites post the LEAP refactor in #829).

## Test plan
- [x] `pytest tests/test_attacked_text.py tests/test_augment_api.py` (non-network-dependent subset): all pass, including two new regression tests (`test_quoted_word` for #723, plus the existing suite covering `Augmenter`/`AttackedText` paths touched here)
- [x] `make lint` clean (black/isort/flake8, matching the pinned CI versions)
- [x] `HuggingFaceModelWrapper` fix manually verified end-to-end against a real tiny seq2seq model (`hf-internal-testing/tiny-random-bart`: confirms `.generate()`+decode now returns strings) and a real classification model (confirms unaffected, still returns logits) and a mock mimicking `T5ForTextToText`'s shape (confirms it's routed around the new branch, not broken by it)
- [x] `Attack.cuda_` fix manually verified with a mocked `torch.nn.Module.to`: a module with `hf_device_map` set is skipped, a normal module is still moved as before
- [ ] `AttackArgs`/`words_diff_ratio`/`words_from_text`/`GreedyWordSwapWIR` fixes are small and locally reasoned/tested via direct interpreter calls (shown in the linked issue comments), but don't yet have dedicated unit tests beyond the one added for #723 — could use follow-up test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)