### PR TITLE
Fix training padding, add train --dataset-from-file, close doc gaps

### DIFF
--- a/docs/0_get_started/quick_api_tour.rst
+++ b/docs/0_get_started/quick_api_tour.rst
@@ -35,3 +35,17 @@ Next, let's build the attack that we want to use. TextAttack provides prebuilt a
 
 
 .. image:: ../_static/imgs/overview.png
+
+
+Attacking a single example
+------------------------------
+The :class:`~textattack.Attacker`/:class:`~textattack.datasets.Dataset` flow above is for running an
+attack over many examples with logging, checkpointing, and parallelism built in. If you just want to
+attack one piece of text, no dataset is needed — call ``.attack()`` directly on the ``Attack`` object
+returned by a recipe's ``build()`` (see https://github.com/QData/TextAttack/issues/673):
+
+.. code-block::
+
+    >>> attack = textattack.attack_recipes.TextFoolerJin2019.build(model_wrapper)
+    >>> result = attack.attack("I really enjoyed this movie.", 1)  # (text, ground_truth_label)
+    >>> print(result.__str__(color_method="ansi"))

--- a/docs/3recipes/attack_recipes.rst
+++ b/docs/3recipes/attack_recipes.rst
@@ -174,5 +174,32 @@ General
    :noindex:
 
 
+Multi-lingual attacks
+############################################
+
+TextAttack also includes recipes for non-English classification models, each a
+language-specific adaptation of a contextualized-perturbation attack (see
+https://github.com/QData/TextAttack/issues/423):
+
+20. FrenchRecipe -- Attack French Recipe (Contextualized Perturbation for French NLP Adversarial Attack)
+21. SpanishRecipe -- Attack Spanish Recipe (Contextualized Perturbation for Spanish NLP Adversarial Attack)
+22. ChineseRecipe -- Attack Chinese Recipe (Contextualized Perturbation for Chinese NLP Adversarial Attack)
+
+
+.. automodule:: textattack.attack_recipes.french_recipe
+   :members:
+   :noindex:
+
+
+.. automodule:: textattack.attack_recipes.spanish_recipe
+   :members:
+   :noindex:
+
+
+.. automodule:: textattack.attack_recipes.chinese_recipe
+   :members:
+   :noindex:
+
+
 
 

--- a/textattack/attack_recipes/seq2sick_cheng_2018_blackbox.py
+++ b/textattack/attack_recipes/seq2sick_cheng_2018_blackbox.py
@@ -28,6 +28,29 @@ class Seq2SickCheng2018BlackBox(AttackRecipe):
 
     This is a greedy re-implementation of the seq2sick attack method. It does
     not use gradient descent.
+
+    Works against any encoder-decoder generation model loaded via
+    :class:`~textattack.models.wrappers.HuggingFaceModelWrapper` (e.g. a raw
+    ``transformers.BartForConditionalGeneration`` or
+    ``transformers.T5ForConditionalGeneration``), not just TextAttack's own
+    ``T5ForTextToText`` helper. See
+    https://github.com/QData/TextAttack/issues/771 and
+    https://github.com/QData/TextAttack/issues/772.
+
+    Example, attacking a BART summarization model directly from
+    ``transformers``::
+
+        import transformers
+        from textattack.attack_recipes import Seq2SickCheng2018BlackBox
+        from textattack.models.wrappers import HuggingFaceModelWrapper
+
+        model = transformers.AutoModelForSeq2SeqLM.from_pretrained("facebook/bart-large-cnn")
+        tokenizer = transformers.AutoTokenizer.from_pretrained("facebook/bart-large-cnn")
+        model_wrapper = HuggingFaceModelWrapper(model, tokenizer)
+
+        attack = Seq2SickCheng2018BlackBox.build(model_wrapper)
+        result = attack.attack(input_text, original_summary)
+        print(result.__str__(color_method="ansi"))
     """
 
     @staticmethod

--- a/textattack/trainer.py
+++ b/textattack/trainer.py
@@ -518,7 +518,11 @@ class Trainer:
         ):
             input_ids = tokenizer(
                 input_texts,
-                padding="max_length",
+                # Pad to the longest sequence in this batch rather than the
+                # tokenizer's static max length: avoids wasted compute on
+                # batches much shorter than the model's max length. See
+                # https://github.com/QData/TextAttack/issues/737
+                padding=True,
                 return_tensors="pt",
                 truncation=True,
             )
@@ -575,7 +579,11 @@ class Trainer:
         if isinstance(model, transformers.PreTrainedModel):
             input_ids = tokenizer(
                 input_texts,
-                padding="max_length",
+                # Pad to the longest sequence in this batch rather than the
+                # tokenizer's static max length: avoids wasted compute on
+                # batches much shorter than the model's max length. See
+                # https://github.com/QData/TextAttack/issues/737
+                padding=True,
                 return_tensors="pt",
                 truncation=True,
             )

--- a/textattack/training_args.py
+++ b/textattack/training_args.py
@@ -16,7 +16,7 @@ from textattack.models.wrappers import (
     PyTorchModelWrapper,
 )
 from textattack.shared import logger
-from textattack.shared.utils import ARGS_SPLIT_TOKEN
+from textattack.shared.utils import ARGS_SPLIT_TOKEN, load_module_from_file
 
 from .attack import Attack
 from .attack_args import ATTACK_RECIPE_NAMES
@@ -342,11 +342,13 @@ class _CommandLineTrainingArgs:
         model_num_labels (int): The number of labels for classification (1 for regression).
         dataset_train_split (str): Name of the train split. If not provided will try `train` as the split name.
         dataset_eval_split (str): Name of the train split. If not provided will try `dev`, `validation`, or `eval` as split name.
+        dataset_from_file (str): Path (optionally `path^module_prefix`) to a Python module that defines
+            `train_dataset` and `eval_dataset`, each a `textattack.datasets.Dataset`. Alternative to `dataset`.
     """
 
     model_name_or_path: str
     attack: str
-    dataset: str
+    dataset: str = None
     task_type: str = "classification"
     model_max_length: int = None
     model_num_labels: int = None
@@ -354,6 +356,7 @@ class _CommandLineTrainingArgs:
     dataset_eval_split: str = None
     filter_train_by_labels: list = None
     filter_eval_by_labels: list = None
+    dataset_from_file: str = None
 
     @classmethod
     def _add_parser_args(cls, parser):
@@ -394,11 +397,20 @@ class _CommandLineTrainingArgs:
         parser.add_argument(
             "--dataset",
             type=str,
-            required=True,
-            default="yelp",
+            required=False,
+            default=None,
             help="dataset for training; will be loaded from "
             "`datasets` library. if dataset has a subset, separate with a colon. "
-            " ex: `glue^sst2` or `rotten_tomatoes`",
+            " ex: `glue^sst2` or `rotten_tomatoes`. Alternative to `--dataset-from-file`.",
+        )
+        parser.add_argument(
+            "--dataset-from-file",
+            type=str,
+            required=False,
+            default=None,
+            help="Path to a Python file (optionally `path^module_prefix`) that defines "
+            "`train_dataset` and `eval_dataset`, each a `textattack.datasets.Dataset`. "
+            "Alternative to `--dataset`. See https://github.com/QData/TextAttack/issues/625",
         )
         parser.add_argument(
             "--dataset-train-split",
@@ -490,6 +502,42 @@ class _CommandLineTrainingArgs:
 
     @classmethod
     def _create_dataset_from_args(cls, args):
+        if args.dataset_from_file:
+            if ARGS_SPLIT_TOKEN in args.dataset_from_file:
+                dataset_file, module_prefix = args.dataset_from_file.split(
+                    ARGS_SPLIT_TOKEN
+                )
+            else:
+                dataset_file, module_prefix = args.dataset_from_file, ""
+            try:
+                dataset_module = load_module_from_file(dataset_file)
+            except Exception:
+                raise ValueError(f"Failed to import file {args.dataset_from_file}")
+            train_var_name = (
+                f"{module_prefix}train_dataset" if module_prefix else "train_dataset"
+            )
+            eval_var_name = (
+                f"{module_prefix}eval_dataset" if module_prefix else "eval_dataset"
+            )
+            try:
+                train_dataset = getattr(dataset_module, train_var_name)
+            except AttributeError:
+                raise AttributeError(
+                    f"Variable `{train_var_name}` not found in module {dataset_file}"
+                )
+            try:
+                eval_dataset = getattr(dataset_module, eval_var_name)
+            except AttributeError:
+                raise AttributeError(
+                    f"Variable `{eval_var_name}` not found in module {dataset_file}"
+                )
+            if args.filter_train_by_labels:
+                train_dataset.filter_by_labels_(args.filter_train_by_labels)
+            if args.filter_eval_by_labels:
+                eval_dataset.filter_by_labels_(args.filter_eval_by_labels)
+            return train_dataset, eval_dataset
+        if not args.dataset:
+            raise ValueError("Must supply either `--dataset` or `--dataset-from-file`.")
         dataset_args = args.dataset.split(ARGS_SPLIT_TOKEN)
         # TODO `HuggingFaceDataset` -> `HuggingFaceDataset`
         if args.dataset_train_split:


### PR DESCRIPTION
## Summary

Third batch from the ongoing issue-triage pass, covering enhancement/documentation issues where investigation turned up a real, boundedly-scoped fix (as opposed to a large new feature — those were left as comments, not implemented, see below).

- **`Trainer.training_step`/`evaluate_step`**: switch from `padding="max_length"` (pads every batch to the tokenizer's static max length) to `padding=True` (pads to the longest sequence in the batch). This was reported and independently validated by the reporter in their own `Trainer` subclass. Fixes #737.
- **`train` command**: add `--dataset-from-file` support. This was a real missing feature, not a latent bug — unlike `attack`/`eval` (which use the shared `DatasetArgs` with full `dataset_from_file` support), `train`'s own arg parser (`_CommandLineTrainingArgs`) never registered the flag at all. Now a Python module can define `train_dataset`/`eval_dataset` (each a `textattack.datasets.Dataset`) and be loaded via `--dataset-from-file path.py` (optionally `path.py^prefix` for `prefix_train_dataset`/`prefix_eval_dataset`). Fixes #625.
- **Docs**: 
  - Document `Attack.attack(text, label)` — the single-example API already exists (it's what `Attacker` calls per-example internally), it just wasn't in the Quick Tour, so users kept assuming they needed a full `Dataset`. Fixes #673.
  - Add a working Python example to `Seq2SickCheng2018BlackBox`'s docstring showing a raw `BartForConditionalGeneration` attack end-to-end, now that #771 (in #831) makes this path actually work. Fixes #772.
  - Add a "Multi-lingual attacks" section listing the three language-specific recipes (`FrenchRecipe`, `SpanishRecipe`, `ChineseRecipe`) that existed but were never documented. Fixes #423.

**Deliberately not implemented** (left as informative comments on the issues instead, since they're substantial new features/design decisions rather than bounded fixes): #636 (timeout mechanism — real feature, needs a design decision on new result types the maintainers themselves didn't converge on), #348 (save all transformed queries — new logger feature), #407 (paraphrase/sentence-level attacks — new attack category), #801 (BU-SPO recipe port — new recipe implementation), #444 (expose victim-model task metadata to transformations — API design question), #558 (WordDeletion + Augmentation `modified_indices` — verified current behavior is no longer *wrong*, just not fully tracking deletions; commented with what I verified rather than guessing at a redesign), #687 (adversarial defense integration — pointed at the relevant open proposal, #824), #731 (noted LEAP (2023) was already added via #829, so "no recipes since 2021" is now stale), #799/#790/#789/#775/#773/#732 (question/support issues — answered directly in comments where I had a confident answer, or asked for the specific info needed where I didn't).

## Test plan
- [x] `pytest tests/test_attacked_text.py tests/test_augment_api.py` (non-network-dependent subset): all pass
- [x] `make lint` clean (black/isort/flake8, pinned CI versions)
- [x] `--dataset-from-file` verified end-to-end against a fake module exposing `train_dataset`/`eval_dataset`
- [x] `textattack train --help` confirms `--dataset-from-file` is registered and the existing `--dataset` flow is untouched
- [ ] The `Trainer` padding change and doc-only changes don't have new automated tests (training is not covered by fast/offline tests in this environment) — logic verified by reading, not an end-to-end training run

🤖 Generated with [Claude Code](https://claude.com/claude-code)