### PR TITLE
CI: switch PyPI publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for PyPI Trusted Publishing (OIDC)
 
     steps:
     - uses: actions/checkout@v4
@@ -16,11 +18,9 @@ jobs:
         python-version: "3.11"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        python -m pip install --upgrade pip setuptools wheel
+    - name: Build package
       run: |
         python setup.py sdist bdist_wheel
-        twine upload dist/*
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

Switches `.github/workflows/publish-to-pypi.yml` from username/password (`twine upload` with `secrets.PYPI_USERNAME`/`PYPI_PASSWORD`) to PyPI's [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) via the official [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) action.

## Why

The `v0.3.11` release attempt just failed at the upload step with `403 Forbidden` from `https://upload.pypi.org/legacy/`. The build itself succeeded (`textattack-0.3.11-py3-none-any.whl` built correctly); PyPI rejected the *upload*, which is what a stale/deprecated username+password credential looks like — PyPI no longer accepts basic-auth uploads for accounts with 2FA enabled (now effectively mandatory for established projects).

Trusted Publishing removes the credential problem entirely: no secrets are stored in the repo at all. GitHub's OIDC token is exchanged directly with PyPI at publish time, scoped to this exact repo + workflow file.

## Required one-time setup (PyPI side, not in this repo)

Before this will work, someone with owner/maintainer access to the `textattack` PyPI project needs to add a Trusted Publisher:

1. Go to https://pypi.org/manage/project/textattack/settings/publishing/
2. Add a new publisher:
   - Owner: `QData`
   - Repository name: `TextAttack`
   - Workflow name: `publish-to-pypi.yml`
   - Environment name: *(leave blank — this workflow doesn't use a GitHub environment)*

Once that's configured, the old `PYPI_USERNAME`/`PYPI_PASSWORD` repo secrets are no longer read by this workflow and can be deleted.

## Test plan
- [x] YAML syntax validated (`yaml.safe_load`)
- [ ] Verify a real release triggers a successful publish once the PyPI-side Trusted Publisher is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)