### PR TITLE
Fix ReadTheDocs build config: deprecated OS image, stale Python pin

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the OS, Python version and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.8"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"


### PR DESCRIPTION
## Summary

Fixes ReadTheDocs builds, which have been failing near-instantly (~2s — a config-level failure, not a real Sphinx/doc content error) since `setup.py`'s `python_requires` was bumped to `>=3.9` in #833.

## Problems

- `.readthedocs.yaml`'s `build.os` was pinned to `ubuntu-20.04`, which ReadTheDocs has since deprecated.
- `build.tools.python` was pinned to `"3.8"`, which no longer satisfies `textattack`'s own `python_requires >= 3.9` — the docs build installs the package itself (`python.install`'s `path: .` entry), so this fails at dependency resolution.

## Fix

Bumped to `ubuntu-24.04` / Python `3.11`, matching what `.github/workflows/make-docs.yml` already uses successfully in CI (that job builds the same Sphinx docs and passes).

## Verification
- [x] Confirmed via ReadTheDocs's public build API that recent `stable` builds are failing with `duration: 2` seconds (consistent with an early config/install failure, not a Sphinx content error)
- [x] YAML syntax validated
- [x] Matches the Python version CI's own (passing) docs-build job already uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)