### PR TITLE
Fix all Sphinx build warnings/errors (19 -> 0)

### DIFF
--- a/docs/api/transformations.rst
+++ b/docs/api/transformations.rst
@@ -11,13 +11,3 @@ Composite Transformation
 .. autoclass:: textattack.transformations.CompositeTransformation
     :members:
 
-
-
-.. toctree::
-   :maxdepth: 6
-
-   textattack.transformations.sentence_transformations
-   textattack.transformations.word_insertions
-   textattack.transformations.word_merges
-   textattack.transformations.word_swaps
-

--- a/textattack/attack_args.py
+++ b/textattack/attack_args.py
@@ -154,9 +154,10 @@ class AttackArgs:
             The number of successful adversarial examples we want. This is different from :obj:`num_examples`
             as :obj:`num_examples` only cares about attacking `N` samples while :obj:`num_successful_examples` aims to keep attacking
             until we have `N` successful cases.
+
             .. note::
                 If set, this argument overrides `num_examples` argument.
-        num_examples_offset (:obj: `int`, `optional`, defaults to :obj:`0`):
+        num_examples_offset (:obj:`int`, `optional`, defaults to :obj:`0`):
             The offset index to start at in the dataset.
         attack_n (:obj:`bool`, `optional`, defaults to :obj:`False`):
             Whether to run attack until total of `N` examples have been attacked (and not skipped).
@@ -167,6 +168,7 @@ class AttackArgs:
         query_budget (:obj:`int`, `optional`, defaults to :obj:`None`):
             The maximum number of model queries allowed per example attacked.
             If not set, we use the query budget set in the :class:`~textattack.goal_functions.GoalFunction` object (which by default is :obj:`float("inf")`).
+
             .. note::
                 Setting this overwrites the query budget set in :class:`~textattack.goal_functions.GoalFunction` object.
         checkpoint_interval (:obj:`int`, `optional`, defaults to :obj:`None`):

--- a/textattack/constraints/grammaticality/language_models/learning_to_write/learning_to_write.py
+++ b/textattack/constraints/grammaticality/language_models/learning_to_write/learning_to_write.py
@@ -24,7 +24,7 @@ class LearningToWriteLanguageModel(LanguageModelConstraint):
 
     https://github.com/windweller/l2w
 
-     Reused by Jia et al., 2019, as a substitution for the Google
+    Reused by Jia et al., 2019, as a substitution for the Google
     1-billion words language model (in a revised version the attack of
     Alzantot et al., 2018).
 

--- a/textattack/goal_function_results/custom/__init__.py
+++ b/textattack/goal_function_results/custom/__init__.py
@@ -1,6 +1,6 @@
 """
 Custom Goal Function Result package:
-=============================
+====================================
 
 Custom goal function results
 

--- a/textattack/goal_function_results/custom/named_entity_recognition_goal_function_result.py
+++ b/textattack/goal_function_results/custom/named_entity_recognition_goal_function_result.py
@@ -1,9 +1,9 @@
 """
 
-NamedEntityRecognitionoalFunctionResult Class
-====================================
+NamedEntityRecognitionGoalFunctionResult Class
+===============================================
 
-logit sum goal function Result
+named entity recognition goal function Result
 
 """
 

--- a/textattack/goal_function_results/custom/targeted_bonus_goal_function_result.py
+++ b/textattack/goal_function_results/custom/targeted_bonus_goal_function_result.py
@@ -1,7 +1,7 @@
 """
 
 TargetedBonusGoalFunctionResult Class
-====================================
+=====================================
 
 targeted bonus goal function Result
 

--- a/textattack/goal_function_results/custom/targeted_strict_goal_function_result.py
+++ b/textattack/goal_function_results/custom/targeted_strict_goal_function_result.py
@@ -1,7 +1,7 @@
 """
 
 TargetedStrictGoalFunctionResult Class
-====================================
+======================================
 
 targeted strict goal function Result
 

--- a/textattack/loggers/json_summary_logger.py
+++ b/textattack/loggers/json_summary_logger.py
@@ -1,6 +1,6 @@
 """
 Attack Summary Results Logs to Json
-========================
+===================================
 """
 
 import json

--- a/textattack/transformations/sentence_transformations/back_transcription.py
+++ b/textattack/transformations/sentence_transformations/back_transcription.py
@@ -34,7 +34,7 @@ class BackTranscription(SentenceTransformation):
 
         >>> augmenter.augment(s)
 
-    You can find more about the back transcription method in the following paper:
+    You can find more about the back transcription method in the following paper::
 
         @inproceedings{kubis-etal-2023-back,
             title = "Back Transcription as a Method for Evaluating Robustness of Natural Language Understanding Models to Speech Recognition Errors",


### PR DESCRIPTION
## Summary

Built the docs locally with `sphinx -b html . _build/html -W --keep-going` (warnings-as-errors, don't stop at the first one) and fixed everything it surfaced — 19 warnings/errors down to a clean `build succeeded`.

## What was found and fixed

- **`docs/api/transformations.rst`**: a broken `toctree` block referencing `textattack.transformations.{sentence_transformations,word_insertions,word_merges,word_swaps}` as if this file lived in `docs/apidoc/` — but it's in `docs/api/`, so none of the four targets resolved (`toctree contains reference to nonexisting document`). Removed it; the same content is already reachable via `docs/apidoc/textattack.transformations.rst`, linked from `index.rst`.
- **`textattack/attack_args.py`**: two `.. note::` blocks nested directly under a docstring paragraph with no blank line before them (invalid RST nesting → `Unexpected indentation`). Also fixed a malformed `` :obj: `int` `` role (stray space breaks the role syntax) — turned out to be the actual cause of a separate ambiguous cross-reference warning (`more than one target found for cross-reference 'num_examples_offset'`, matching both `AttackArgs` and `ModelEvalArgs`) once fixed.
- **`textattack/constraints/.../learning_to_write.py`**: a docstring paragraph had one extra leading space versus its sibling paragraphs, so RST parsed it as an indented block quote.
- **`textattack/transformations/.../back_transcription.py`**: a BibTeX citation block wasn't marked as a literal block, so RST tried (and failed) to parse its internal indentation as nested block-quotes/definition-lists. Marked it literal with `::`, matching the `Example::` block already used above it in the same docstring.
- **Five files** ("Title underline too short"): extended each RST title underline to match its title's actual length. One of these (`named_entity_recognition_goal_function_result.py`) also had a real content bug: the module docstring title was misspelled (`...Recognitio`**n**`oalFunctionResult`, missing the "G" in "Goal") and its one-line description was copy-pasted from `logit_sum`'s file ("logit sum goal function Result") instead of describing this class.

## Why this matters now

None of these had actually broken CI's docs build before, because `.readthedocs.yaml`'s build config itself was broken first (see #836) — RTD's build was failing at the config/install step, before ever reaching Sphinx. Once #836 lands and RTD can actually run Sphinx, these are exactly the warnings that build would hit.

## Verification
- [x] Clean local Sphinx build: `build succeeded` with zero warnings/errors (confirmed via `-W --keep-going`, both incrementally after each fix and as a final full clean rebuild)
- [x] All edited modules still import correctly (docstring edits don't affect runtime, but confirmed no syntax breakage)
- [x] `black --check` / `flake8` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)