### PR TITLE
Fix SklearnModelWrapper: get_feature_names() removed in sklearn 1.2+

### DIFF
--- a/docs/2notebook/Example_1_sklearn.ipynb
+++ b/docs/2notebook/Example_1_sklearn.ipynb
@@ -72,7 +72,7 @@
     }
    ],
    "source": [
-    "!pip install datasets nltk sklearn"
+    "!pip install datasets nltk scikit-learn"
    ]
   },
   {
@@ -295,11 +295,11 @@
     "    vectFit = vect.fit(training[column_name])\n",
     "    BOW_training = vectFit.transform(training[column_name])\n",
     "    BOW_training_df = pd.DataFrame(\n",
-    "        BOW_training.toarray(), columns=vect.get_feature_names()\n",
+    "        BOW_training.toarray(), columns=vect.get_feature_names_out()\n",
     "    )\n",
     "    BOW_testing = vectFit.transform(testing[column_name])\n",
     "    BOW_testing_Df = pd.DataFrame(\n",
-    "        BOW_testing.toarray(), columns=vect.get_feature_names()\n",
+    "        BOW_testing.toarray(), columns=vect.get_feature_names_out()\n",
     "    )\n",
     "    return vectFit, BOW_training_df, BOW_testing_Df\n",
     "\n",
@@ -311,11 +311,11 @@
     "    Tfidf_fit = Tfidf.fit(training[column_name])\n",
     "    Tfidf_training = Tfidf_fit.transform(training[column_name])\n",
     "    Tfidf_training_df = pd.DataFrame(\n",
-    "        Tfidf_training.toarray(), columns=Tfidf.get_feature_names()\n",
+    "        Tfidf_training.toarray(), columns=Tfidf.get_feature_names_out()\n",
     "    )\n",
     "    Tfidf_testing = Tfidf_fit.transform(testing[column_name])\n",
     "    Tfidf_testing_df = pd.DataFrame(\n",
-    "        Tfidf_testing.toarray(), columns=Tfidf.get_feature_names()\n",
+    "        Tfidf_testing.toarray(), columns=Tfidf.get_feature_names_out()\n",
     "    )\n",
     "    return Tfidf_fit, Tfidf_training_df, Tfidf_testing_df\n",
     "\n",

--- a/textattack/models/wrappers/sklearn_model_wrapper.py
+++ b/textattack/models/wrappers/sklearn_model_wrapper.py
@@ -23,7 +23,7 @@ class SklearnModelWrapper(ModelWrapper):
     def __call__(self, text_input_list, batch_size=None):
         encoded_text_matrix = self.tokenizer.transform(text_input_list).toarray()
         tokenized_text_df = pd.DataFrame(
-            encoded_text_matrix, columns=self.tokenizer.get_feature_names()
+            encoded_text_matrix, columns=self.tokenizer.get_feature_names_out()
         )
         return self.model.predict_proba(tokenized_text_df)
 


### PR DESCRIPTION
## Summary

`SklearnModelWrapper.__call__` calls `self.tokenizer.get_feature_names()` — but `tokenizer` here is actually a fitted `CountVectorizer`/`TfidfVectorizer`, and `get_feature_names()` was **removed from scikit-learn in 1.2** (Dec 2022) in favor of `get_feature_names_out()` (available since 1.0). Any use of `SklearnModelWrapper` — including its own demo notebook, `docs/2notebook/Example_1_sklearn.ipynb` — has been broken with any scikit-learn released in the last several years, raising `AttributeError` on the first real prediction call.

## Fix

- `textattack/models/wrappers/sklearn_model_wrapper.py`: `get_feature_names()` → `get_feature_names_out()`.
- `docs/2notebook/Example_1_sklearn.ipynb`: same fix in the 4 places the notebook does its own vectorizer → DataFrame conversion. Also fixed `!pip install datasets nltk sklearn` → `scikit-learn` — the `sklearn` PyPI package name is deprecated and its installer now aborts with an explicit error directing users to `scikit-learn` instead.

The notebook fix was applied as a surgical text substitution (not a full cell replace), so the notebook's existing recorded outputs and execution counts — the demonstrated training accuracy / attack results from a real prior run — are left intact rather than wiped.

## Verification
- [x] Reproduced the `AttributeError` directly against the currently pinned scikit-learn (1.7.2): `CountVectorizer().get_feature_names()` → `AttributeError: 'CountVectorizer' object has no attribute 'get_feature_names'`
- [x] Confirmed `get_feature_names_out()` works end-to-end through the actual wrapper (fit a real `CountVectorizer` + `LogisticRegression`, ran predictions through `SklearnModelWrapper`)
- [x] Notebook JSON validated (`json.load`) after the edit; diff is minimal (5 lines) and doesn't touch stored outputs
- [x] `black --check` / `flake8` clean; `from textattack.models.wrappers import SklearnModelWrapper` still imports cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)